### PR TITLE
Consensus Memory Limits

### DIFF
--- a/C/dag.h
+++ b/C/dag.h
@@ -299,7 +299,7 @@ static inline size_t WITNESS_B(const dag_node* dag, const type* type_dag, size_t
  *
  * such that
  *
- *     0 < len
+ *     1 <= len <= DAG_LEN_MAX
  *
  * and for all 'i', 0 <= 'i' < 'len' and for all 'j', 0 <= 'j' < 'numChildren(dag[i].tag)',
  *

--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
+#include "limitations.h"
 #include "primitive.h"
 #include "unreachable.h"
 
@@ -188,8 +189,11 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   *dag = NULL;
   int32_t dagLen = decodeUptoMaxInt(stream);
   if (dagLen <= 0) return dagLen;
-  /* :TODO: a consensus parameter limiting the maximum length of a DAG needs to be enforced here */
-  if (PTRDIFF_MAX / sizeof(dag_node) < (size_t)dagLen) return SIMPLICITY_ERR_DATA_OUT_OF_RANGE;
+  static_assert(DAG_LEN_MAX <= (uint32_t)INT32_MAX, "DAG_LEN_MAX exceeds supported parsing range.");
+  if (DAG_LEN_MAX < (uint32_t)dagLen) return SIMPLICITY_ERR_DATA_OUT_OF_RANGE;
+  static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(dag_node), "dag array too large.");
+  static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
+  static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "dag array index does not fit in uint32_t.");
   *dag = malloc((size_t)dagLen * sizeof(dag_node));
   if (!*dag) return SIMPLICITY_ERR_MALLOC;
 

--- a/C/limitations.h
+++ b/C/limitations.h
@@ -1,0 +1,9 @@
+#ifndef SIMPLICITY_LIMITATIONS_H
+#define SIMPLICITY_LIMITATIONS_H
+
+#define DAG_LEN_MAX 0x800000U
+#define NUMBER_OF_TYPENAMES_MAX 0x1000U
+_Static_assert(DAG_LEN_MAX <= SIZE_MAX , "DAG_LEN_MAX doesn't fit in size_t.");
+_Static_assert(NUMBER_OF_TYPENAMES_MAX <= SIZE_MAX, "NUMBER_OF_TYPENAMES_MAX doesn't fit in size_t.");
+
+#endif

--- a/C/limitations.h
+++ b/C/limitations.h
@@ -3,7 +3,9 @@
 
 #define DAG_LEN_MAX 0x800000U
 #define NUMBER_OF_TYPENAMES_MAX 0x1000U
+#define CELLS_MAX 0x500000U /* 5120 Kibibits ought to be enough for anyone. */
 _Static_assert(DAG_LEN_MAX <= SIZE_MAX , "DAG_LEN_MAX doesn't fit in size_t.");
 _Static_assert(NUMBER_OF_TYPENAMES_MAX <= SIZE_MAX, "NUMBER_OF_TYPENAMES_MAX doesn't fit in size_t.");
+_Static_assert(CELLS_MAX <= SIZE_MAX, "CELLS_MAX doesn't fit in size_t.");
 
 #endif

--- a/C/primitive.h
+++ b/C/primitive.h
@@ -16,6 +16,7 @@
  * Precondition: NULL != bound_var;
  *               NULL != word256_ix;
  *               NULL != extra_var_start;
+ *               extra_var_len <= 6*DAG_LEN_MAX;
  *
  * Postcondition: Either '*bound_var == NULL' and the function returns 0
  *                or 'unification_var (*bound_var)[*extra_var_start + extra_var_len]' is an array of unification variables

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "limitations.h"
 #include "sha256.h"
 
 _Static_assert(UCHAR_MAX < SIZE_MAX, "UCHAR_MAX >= SIZE_MAX");
@@ -20,15 +21,23 @@ const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t 
  *
  * Precondition: NULL != duplicates;
  *               const sha256_midstate a[len];
+ *               len <= DAG_LEN_MAX;
  */
 static inline bool hasDuplicates(bool* duplicates, const sha256_midstate* a, size_t len) {
-  _Static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding");
-  _Static_assert(sizeof(a->s) < SIZE_MAX / CHAR_COUNT, "CHAR_BIT is way too large");
-  _Static_assert((sizeof(a->s) + 1) * CHAR_COUNT <= SIZE_MAX/sizeof(size_t), "sizeof(size_t) is way too large");
+  if (0 == len) {
+    *duplicates = false;
+    return true;
+  }
+  static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding.");
+  static_assert(sizeof(a->s) < SIZE_MAX / CHAR_COUNT, "CHAR_BIT is way too large.");
+  static_assert((sizeof(a->s) + 1) * CHAR_COUNT <= SIZE_MAX/sizeof(size_t), "sizeof(size_t) is way too large.");
   size_t * scratch = malloc((sizeof(a->s) + 1) * CHAR_COUNT * sizeof(size_t));
-  const sha256_midstate **perm = len <= SIZE_MAX/sizeof(const sha256_midstate*)
-                               ? malloc(len * sizeof(const sha256_midstate*))
-                               : NULL;
+  static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(const sha256_midstate*), "perm array too large.");
+  static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
+  static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "perm array index does not fit in uint32_t.");
+  assert(len <= SIZE_MAX / sizeof(const sha256_midstate*));
+  assert(len - 1 <= UINT32_MAX);
+  const sha256_midstate **perm = malloc(len * sizeof(const sha256_midstate*));
   bool result = scratch && perm;
 
   if (result) {


### PR DESCRIPTION
Add a dag length maximum value of 8 Mibi nodes.  The current encoding can fit at most two nodes per byte (two witness nodes).  As it stands, this dag length maximum value is unachievable given a blocksize limit of 4 Megabytes.  However, we may want to bring this limit down before final release.

We also add a cell limit of 5 Mibi cells.  This is slightly larger than Script's stack·item size limit in bits.

There is also a`NUMBER_OF_TYPENAMES_MAX` limit, but this is an implementation limit rather than a consensus limit.  Basically I didn't see a good way of exporting the `NumberOfTypeNames` value, so instead I put a bound of 1 Kibi on it for accounting purposes.  This bounds how large the various types of the jets are allowed to get.  It could be increased if it ever became necessary.  The current value of `NumberOfTypeNames` is 106.