### PR TITLE
Early failure for HIDDEN root nodes.

### DIFF
--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -170,6 +170,7 @@ static simplicity_err decodeDag(dag_node* dag, const size_t len, combinator_coun
  *  (all fail subexpressions ought to have been pruned prior to deserialization).
  * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if there are illegal HIDDEN children in the DAG.
+ * Returns 'SIMPLICITY_ERR_HIDDEN_ROOT' if the root of the DAG is a HIDDEN node.
  * Returns 'SIMPLICITY_ERR_BITSTRING_EOF' if not enough bits are available in the 'stream'.
  * Returns 'SIMPLICITY_ERR_DATA_OUT_OF_ORDER' if nodes are not serialized in the canonical order.
  * Returns 'SIMPLICITY_ERR_MALLOC' if malloc fails.
@@ -201,7 +202,9 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   simplicity_err error = decodeDag(*dag, (size_t)dagLen, census, stream);
 
   if (IS_OK(error)) {
-    error = verifyCanonicalOrder(*dag, (size_t)(dagLen));
+    error = HIDDEN == (*dag)[dagLen - 1].tag
+          ? SIMPLICITY_ERR_HIDDEN_ROOT
+          : verifyCanonicalOrder(*dag, (size_t)(dagLen));
   }
 
   if (IS_OK(error)) {

--- a/C/deserialize.h
+++ b/C/deserialize.h
@@ -13,6 +13,7 @@
  *  (all fail subexpressions ought to have been pruned prior to deserialization).
  * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if there are illegal HIDDEN children in the DAG.
+ * Returns 'SIMPLICITY_ERR_HIDDEN_ROOT' if the root of the DAG is a HIDDEN node.
  * Returns 'SIMPLICITY_ERR_BITSTRING_EOF' if not enough bits are available in the 'stream'.
  * Returns 'SIMPLICITY_ERR_MALLOC' if malloc fails.
  * In the above error cases, '*dag' is set to NULL.

--- a/C/eval.c
+++ b/C/eval.c
@@ -830,7 +830,7 @@ static bool computeEvalTCOBound(memBound *dag_bound, const dag_node* dag, const 
  *
  * Otherwise 'SIMPLICITY_NO_ERROR' is returned.
  *
- * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' of type A |- B;
+ * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' for an expression of type A |- B;
  *               inputSize == bitSize(A);
  *               outputSize == bitSize(B);
  *               output == NULL or UWORD output[ROUND_UWORD(outputSize)];

--- a/C/eval.h
+++ b/C/eval.h
@@ -28,7 +28,7 @@ typedef unsigned char flags_type;
  *
  * Otherwise 'SIMPLICITY_NO_ERROR' is returned.
  *
- * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' of type A |- B;
+ * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' for an expression of type A |- B;
  *               inputSize == bitSize(A);
  *               outputSize == bitSize(B);
  *               output == NULL or UWORD output[ROUND_UWORD(outputSize)];
@@ -52,7 +52,7 @@ simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, ubo
  *
  * Otherwise 'SIMPLICITY_NO_ERROR' is returned.
  *
- * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' of type 1 |- 1;
+ * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' for an expression of type ONE |- ONE;
  *               budget <= BUDGET_MAX
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -34,6 +34,7 @@ typedef enum {
   SIMPLICITY_ERR_EXEC_JET = -38,
   SIMPLICITY_ERR_EXEC_ASSERT = -40,
   SIMPLICITY_ERR_ANTIDOS = -42,
+  SIMPLICITY_ERR_HIDDEN_ROOT = -44,
 } simplicity_err;
 
 /* Check if failure is permanent (or success which is always permanent). */
@@ -65,7 +66,7 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
   case SIMPLICITY_ERR_STOP_CODE:
     return "Program has STOP node";
   case SIMPLICITY_ERR_HIDDEN:
-    return "Program has illegal HIDDEN node";
+    return "Program has illegal HIDDEN child node";
   case SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES:
     return "Unused bytes at the end of the program";
   case SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS:
@@ -96,6 +97,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Assertion failed";
   case SIMPLICITY_ERR_ANTIDOS:
     return "Anti-DOS check failed";
+  case SIMPLICITY_ERR_HIDDEN_ROOT:
+    return "Program's root is HIDDEN";
   default:
     return "Unknown error code";
   }


### PR DESCRIPTION
Currently if a DAG consists of exactly one node that is a HIDDEN node it passes all validation until finally failing during evaluation. This commit causes this case to fail right away.

Fixes #155