### PR TITLE
Weight

### DIFF
--- a/C/ctx8Pruned.c
+++ b/C/ctx8Pruned.c
@@ -275,3 +275,6 @@ const uint32_t ctx8Pruned_imr[] = {
 const uint32_t ctx8Pruned_amr[] = {
   0x1e45ed6du, 0x87f0a9cfu, 0x2875284au, 0x4c9f08cbu, 0x305ac379u, 0x1b86ae18u, 0x00a4f2b2u, 0x256d1299u
 };
+
+/* The cost of the above ctx8Pruned Simplicity expression in milli weight units. */
+const ubounded ctx8Pruned_cost = 30964831;

--- a/C/ctx8Pruned.h
+++ b/C/ctx8Pruned.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     (scribe (toWord256 0x067C531269735CA7F541FDACA8F0DC76305D3CADA140F89372A410FE5EFF6E4D) &&&
@@ -20,5 +21,8 @@ extern const uint32_t ctx8Pruned_imr[];
 
 /* The annotated Merkle root of the above ctx8Pruned Simplicity expression. */
 extern const uint32_t ctx8Pruned_amr[];
+
+/* The cost of the above ctx8Pruned Simplicity expression in milli weight units. */
+extern const ubounded ctx8Pruned_cost;
 
 #endif

--- a/C/ctx8Unpruned.c
+++ b/C/ctx8Unpruned.c
@@ -265,3 +265,6 @@ const uint32_t ctx8Unpruned_imr[] = {
 const uint32_t ctx8Unpruned_amr[] = {
   0xcd6dfe2eu, 0x0579451du, 0x65c1d64du, 0xb488bfd8u, 0x94800a7cu, 0xd9a966bau, 0x9c232b6fu, 0xd643ba00u
 };
+
+/* The cost of the above ctx8Unpruned Simplicity expression in milli weight units. */
+const ubounded ctx8Unpruned_cost = 730611815;

--- a/C/ctx8Unpruned.h
+++ b/C/ctx8Unpruned.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     (scribe (toWord256 0x067C531269735CA7F541FDACA8F0DC76305D3CADA140F89372A410FE5EFF6E4D) &&&
@@ -20,5 +21,8 @@ extern const uint32_t ctx8Unpruned_imr[];
 
 /* The annotated Merkle root of the above ctx8Unpruned Simplicity expression. */
 extern const uint32_t ctx8Unpruned_amr[];
+
+/* The cost of the above ctx8Unpruned Simplicity expression in milli weight units. */
+extern const ubounded ctx8Unpruned_cost;
 
 #endif

--- a/C/eval.h
+++ b/C/eval.h
@@ -12,8 +12,8 @@ typedef unsigned char flags_type;
 #define CHECK_CASE 0x60
 #define CHECK_ALL ((flags_type)(-1))
 
-/* Run the Bit Machine on the well-typed Simplicity expression 'dag[len]'.
- * If 'NULL != input', initialize the active read frame's data with 'input[ROUND_UWORD(inputSize)]'.
+/* Run the Bit Machine on the well-typed Simplicity expression 'dag[len]' of type A |- B.
+ * If bitSize(A) > 0, initialize the active read frame's data with 'input[ROUND_UWORD(bitSize(A))]'.
  *
  * If malloc fails, returns 'SIMPLICITY_ERR_MALLOC'.
  * If static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'
@@ -21,7 +21,7 @@ typedef unsigned char flags_type;
  * If during execution some jet execution fails, returns 'SIMPLICITY_ERR_EXEC_JET'.
  * If during execution some 'assertr' or 'assertl' combinator fails, returns 'SIMPLICITY_ERR_EXEC_ASESRT'.
  *
- * If none of the above conditions fail and 'NULL != output', then a copy the final active write frame's data is written to 'output[roundWord(outputSize)]'.
+ * If none of the above conditions fail and bitSize(B) > 0, then a copy the final active write frame's data is written to 'output[roundWord(bitSize(B))]'.
  *
  * If 'anti_dos_checks' includes the 'CHECK_EXEC' flag, and not every non-HIDDEN dag node is executed, returns 'SIMPLICITY_ERR_ANTIDOS'
  * If 'anti_dos_checks' includes the 'CHECK_CASE' flag, and not every case node has both branches executed, returns 'SIMPLICITY_ERR_ANTIDOS'
@@ -29,14 +29,12 @@ typedef unsigned char flags_type;
  * Otherwise 'SIMPLICITY_NO_ERROR' is returned.
  *
  * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' for an expression of type A |- B;
- *               inputSize == bitSize(A);
- *               outputSize == bitSize(B);
- *               output == NULL or UWORD output[ROUND_UWORD(outputSize)];
- *               input == NULL or UWORD input[ROUND_UWORD(inputSize)];
+ *               bitSize(A) == 0 or UWORD input[ROUND_UWORD(bitSize(A))];
+ *               bitSize(B) == 0 or UWORD output[ROUND_UWORD(bitSize(B))];
  *               budget <= BUDGET_MAX
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
-simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, ubounded outputSize, const UWORD* input, ubounded inputSize
+simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, const UWORD* input
                                 , const dag_node* dag, type* type_dag, size_t len, ubounded budget, const txEnv* env
                                 );
 
@@ -57,6 +55,6 @@ simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, ubo
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
 static inline simplicity_err evalTCOProgram(const dag_node* dag, type* type_dag, size_t len, ubounded budget, const txEnv* env) {
-  return evalTCOExpression(CHECK_ALL, NULL, 0, NULL, 0, dag, type_dag, len, budget, env);
+  return evalTCOExpression(CHECK_ALL, NULL, NULL, dag, type_dag, len, budget, env);
 }
 #endif

--- a/C/eval.h
+++ b/C/eval.h
@@ -12,6 +12,30 @@ typedef unsigned char flags_type;
 #define CHECK_CASE 0x60
 #define CHECK_ALL ((flags_type)(-1))
 
+/* Given a well-typed dag representing a Simplicity expression, compute the memory and CPU requirements for evaluation.
+ *
+ * If 'malloc' fails, then returns SIMPLICITY_ERR_MALLOC.
+ * If the bounds on the number of cells needed for evaluation of 'dag' on an idealized Bit Machine exceeds maxCells,
+ * then return SIMPLICITY_ERR_EXEC_MEMORY.
+ * If the bounds on the dag's CPU cost exceeds 'maxCost', then return SIMPLICITY_ERR_EXEC_BUDGET.
+ * Otherwise returns SIMPLICITY_NO_ERR.
+ *
+ * Precondition: NULL != cellsBound
+ *               NULL != UWORDBound
+ *               NULL != frameBound
+ *               NULL != costBound
+ *               maxCells < BOUNDED_MAX
+ *               maxCost < BOUNDED_MAX
+ *               dag_node dag[len] and 'dag' is well-typed with 'type_dag'.
+ * Postcondition: if the result is 'SIMPLICITY_NO_ERR'
+ *                then '*costBound' bounds the dag's CPU cost measured in milli weight units
+ *                 and '*cellsBound' bounds the number of cells needed for evaluation of 'dag' on an idealized Bit Machine
+ *                 and '*UWORDBound' bounds the number of UWORDs needed for the frames during evaluation of 'dag'
+ *                 and '*frameBound' bounds the number of stack frames needed during execution of 'dag'.
+ */
+simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubounded *frameBound, ubounded *costBound
+                            , ubounded maxCells, ubounded maxCost, const dag_node* dag, const type* type_dag, const size_t len);
+
 /* Run the Bit Machine on the well-typed Simplicity expression 'dag[len]' of type A |- B.
  * If bitSize(A) > 0, initialize the active read frame's data with 'input[ROUND_UWORD(bitSize(A))]'.
  *

--- a/C/hashBlock.c
+++ b/C/hashBlock.c
@@ -185,3 +185,6 @@ const uint32_t hashBlock_imr[] = {
 const uint32_t hashBlock_amr[] = {
   0x23c7a58cu, 0x03a95c10u, 0xa933da89u, 0x5fe28dbbu, 0x3d12652bu, 0x3d3d1e7du, 0x5805683fu, 0xbca2c63bu
 };
+
+/* The cost of the above hashBlock Simplicity expression in milli weight units. */
+const ubounded hashBlock_cost = 29099602;

--- a/C/hashBlock.h
+++ b/C/hashBlock.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     hashBlock
@@ -18,5 +19,8 @@ extern const uint32_t hashBlock_imr[];
 
 /* The annotated Merkle root of the above hashBlock Simplicity expression. */
 extern const uint32_t hashBlock_amr[];
+
+/* The cost of the above hashBlock Simplicity expression in milli weight units. */
+extern const ubounded hashBlock_cost;
 
 #endif

--- a/C/primitive/elements/checkSigHashAllTx1.c
+++ b/C/primitive/elements/checkSigHashAllTx1.c
@@ -32,3 +32,6 @@ const uint32_t elementsCheckSigHashAllTx1_imr[] = {
 const uint32_t elementsCheckSigHashAllTx1_amr[] = {
   0xd86bfbeau, 0x33d8a02fu, 0xf921652eu, 0x7dce5bd5u, 0x69f19d9fu, 0x6507012au, 0x5fc0c4f5u, 0x5af314eau
 };
+
+/* The cost of the above elementsCheckSigHashAllTx1 Simplicity expression in milli weight units. */
+const ubounded elementsCheckSigHashAllTx1_cost = 564755;

--- a/C/primitive/elements/checkSigHashAllTx1.c
+++ b/C/primitive/elements/checkSigHashAllTx1.c
@@ -34,4 +34,4 @@ const uint32_t elementsCheckSigHashAllTx1_amr[] = {
 };
 
 /* The cost of the above elementsCheckSigHashAllTx1 Simplicity expression in milli weight units. */
-const ubounded elementsCheckSigHashAllTx1_cost = 564755;
+const ubounded elementsCheckSigHashAllTx1_cost = 53277;

--- a/C/primitive/elements/checkSigHashAllTx1.h
+++ b/C/primitive/elements/checkSigHashAllTx1.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "../../bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     Simplicity.Programs.CheckSig.Lib.checkSigVerify' Simplicity.Elements.Programs.SigHash.Lib.sigAllHash
@@ -22,5 +23,8 @@ extern const uint32_t elementsCheckSigHashAllTx1_imr[];
 
 /* The annotated Merkle root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
 extern const uint32_t elementsCheckSigHashAllTx1_amr[];
+
+/* The cost of the above elementsCheckSigHashAllTx1 Simplicity expression in milli weight units. */
+extern const ubounded elementsCheckSigHashAllTx1_cost;
 
 #endif

--- a/C/schnorr0.c
+++ b/C/schnorr0.c
@@ -35,4 +35,4 @@ const uint32_t schnorr0_amr[] = {
 };
 
 /* The cost of the above schnorr0 Simplicity expression in milli weight units. */
-const ubounded schnorr0_cost = 564301;
+const ubounded schnorr0_cost = 52823;

--- a/C/schnorr0.c
+++ b/C/schnorr0.c
@@ -33,3 +33,6 @@ const uint32_t schnorr0_imr[] = {
 const uint32_t schnorr0_amr[] = {
   0x02796d1du, 0x7d906a15u, 0xd0a1ebedu, 0x9d702e33u, 0x4b21e9ccu, 0x52a578c2u, 0x4fca0fb7u, 0xbe82fac0u
 };
+
+/* The cost of the above schnorr0 Simplicity expression in milli weight units. */
+const ubounded schnorr0_cost = 564301;

--- a/C/schnorr0.h
+++ b/C/schnorr0.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     (scribe (toWord256 0xF9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9) &&&
@@ -22,5 +23,8 @@ extern const uint32_t schnorr0_imr[];
 
 /* The annotated Merkle root of the above schnorr0 Simplicity expression. */
 extern const uint32_t schnorr0_amr[];
+
+/* The cost of the above schnorr0 Simplicity expression in milli weight units. */
+extern const ubounded schnorr0_cost;
 
 #endif

--- a/C/schnorr6.c
+++ b/C/schnorr6.c
@@ -35,4 +35,4 @@ const uint32_t schnorr6_amr[] = {
 };
 
 /* The cost of the above schnorr6 Simplicity expression in milli weight units. */
-const ubounded schnorr6_cost = 564301;
+const ubounded schnorr6_cost = 52823;

--- a/C/schnorr6.c
+++ b/C/schnorr6.c
@@ -33,3 +33,6 @@ const uint32_t schnorr6_imr[] = {
 const uint32_t schnorr6_amr[] = {
   0xcd11f8adu, 0xd83967e4u, 0x4fbb1197u, 0x88e40e74u, 0xe88a842fu, 0x8211592eu, 0xac98e6c7u, 0xb5b3814cu
 };
+
+/* The cost of the above schnorr6 Simplicity expression in milli weight units. */
+const ubounded schnorr6_cost = 564301;

--- a/C/schnorr6.h
+++ b/C/schnorr6.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bounded.h"
 
 /* A length-prefixed encoding of the following Simplicity program:
  *     (scribe (toWord256 0xDFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659) &&&
@@ -22,5 +23,8 @@ extern const uint32_t schnorr6_imr[];
 
 /* The annotated Merkle root of the above schnorr6 Simplicity expression. */
 extern const uint32_t schnorr6_amr[];
+
+/* The cost of the above schnorr6 Simplicity expression in milli weight units. */
+extern const ubounded schnorr6_cost;
 
 #endif

--- a/C/test.c
+++ b/C/test.c
@@ -119,7 +119,7 @@ static void test_hashBlock(void) {
         /* Set the block to be compressed to "abc" with padding. */
         write32s(&frame, (uint32_t[16]){ [0] = 0x61626380, [15] = 0x18 }, 16);
       }
-      if (IS_OK(evalTCOExpression(CHECK_NONE, output, outputBitSize, input, inputBitSize, dag, type_dag, (size_t)len, 29100, NULL))) {
+      if (IS_OK(evalTCOExpression(CHECK_NONE, output, input, dag, type_dag, (size_t)len, 29100, NULL))) {
         /* The expected result is the value 'SHA256("abc")'. */
         const uint32_t expectedHash[8] = { 0xba7816bful, 0x8f01cfeaul, 0x414140deul, 0x5dae2223ul
                                          , 0xb00361a3ul, 0x96177a9cul, 0xb410ff61ul, 0xf20015adul };

--- a/Haskell/Core/Simplicity/BitMachine/StaticAnalysis/Cost.hs
+++ b/Haskell/Core/Simplicity/BitMachine/StaticAnalysis/Cost.hs
@@ -1,6 +1,7 @@
 module Simplicity.BitMachine.StaticAnalysis.Cost
   ( TermWeight(..)
   , overhead
+  , milliWeigh
 -- * Reexports
   , Weight
   ) where
@@ -13,6 +14,10 @@ import Simplicity.Weight
 --
 -- Note that serializing an expression could generalize the types of expressions and sub-expressions, lowering the weight.
 newtype TermWeight a b = TermWeight { weigh :: Weight }
+
+-- | Cost of a term in milli weight units
+milliWeigh :: TermWeight a b -> Integer
+milliWeigh = milliWeight . weigh
 
 instance Core TermWeight where
   iden = result

--- a/Haskell/Core/Simplicity/BitMachine/StaticAnalysis/Cost.hs
+++ b/Haskell/Core/Simplicity/BitMachine/StaticAnalysis/Cost.hs
@@ -40,7 +40,7 @@ instance Assert TermWeight where
 instance Witness TermWeight where
   witness _ = result
    where
-    result = TermWeight $ fromInteger (bitSizeR (reifyProxy result))
+    result = TermWeight $ overhead + milli (bitSizeR (reifyProxy result))
 
 instance Delegate TermWeight where
   disconnect s0@(TermWeight s) t0@(TermWeight t) = TermWeight $ overhead + milli (2 * bitSizeR (reifyProxy s0) + bitSizeR (reifyProxy t0)) + s + t

--- a/Haskell/Indef/Simplicity/Dag.hs
+++ b/Haskell/Indef/Simplicity/Dag.hs
@@ -277,7 +277,7 @@ instance JetType jt => Delegate (JetDag jt) where
   disconnect = mkBinary disconnect disconnect uDisconnect
 
 instance JetType jt => Primitive (JetDag jt)  where
-  primitive p = mkLeaf (primitive p) (primitive p) (Prim (SomeArrow p))
+  primitive p = mkLeaf (primitive p) (primitive p) (error "Primitives cannot be directly serialized.  They can only be part of jet specifications.")
 
 -- Exisiting jets are discarded when coverting to a dag.  They are reconstructed using a jet matcher.
 instance JetType jt => Jet (JetDag jt) where

--- a/Haskell/Indef/Simplicity/StaticAnalysis/Cost.hs
+++ b/Haskell/Indef/Simplicity/StaticAnalysis/Cost.hs
@@ -1,0 +1,11 @@
+module Simplicity.StaticAnalysis.Cost
+  ( module Cost
+  ) where
+
+import Simplicity.BitMachine.StaticAnalysis.Cost as Cost
+import Simplicity.Term
+
+instance Jet TermWeight where
+  jet w _t = TermWeight w
+
+instance Simplicity TermWeight where

--- a/Haskell/Indef/Simplicity/Term.hs
+++ b/Haskell/Indef/Simplicity/Term.hs
@@ -37,7 +37,7 @@ instance (MonadReader PrimEnv m, Fail.MonadFail m) => Primitive (Kleisli m) wher
 
 -- | This class creates expressions for discounted jets.
 -- A jet's specification is a Simplicity expression that isn't allowed to contain witness data, delgations or other jets.
-class (Assert term, Primitive term) => Jet term where
+class Assert term => Jet term where
   jet :: (TyC a, TyC b) => Weight -> (forall term0. (Assert term0, Primitive term0) => term0 a b) -> term a b
 
 -- | The Monad 'm' should be a commutative monad.

--- a/Haskell/Tests/Simplicity/Bitcoin/Serialization/Tests.hs
+++ b/Haskell/Tests/Simplicity/Bitcoin/Serialization/Tests.hs
@@ -107,7 +107,6 @@ compareDag compareWitness v1 v2 = (and $ zipWith compareNode v1 v2) && (length v
   compareNode (Disconnect _ _ _ _ x0 y0) (Disconnect _ _ _ _ x1 y1) = [x0,y0] == [x1,y1]
   compareNode (Hidden h0) (Hidden h1) = h0 == h1
   compareNode (Witness _ b0 w0) (Witness _ b1 w1) = compareWitness b0 w0 b1 w1
-  compareNode (Prim p0) (Prim p1) = p0 == p1
   compareNode (Jet j0) (Jet j1) = j0 == j1
   compareNode _ _ = False
 

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -101,7 +101,8 @@ library Simplicity-Indef
                        Simplicity.Semantics,
                        Simplicity.Dag, Simplicity.Inference
                        Simplicity.JetType,
-                       Simplicity.Serialization.BitString, Simplicity.Serialization.ByteString
+                       Simplicity.Serialization.BitString, Simplicity.Serialization.ByteString,
+                       Simplicity.StaticAnalysis.Cost
   signatures:          Simplicity.Primitive
   other-extensions:    EmptyCase, EmptyDataDecls, EmptyDataDeriving,
                        ScopedTypeVariables,
@@ -175,6 +176,7 @@ library
                        Simplicity.Elements.JetType,
                        Simplicity.Elements.Serialization.BitString,
                        Simplicity.Elements.Serialization.ByteString,
+                       Simplicity.Elements.StaticAnalysis.Cost,
                        Simplicity.Weight
   mixins:              Simplicity-Indef
                          (Simplicity.Term as Simplicity.Bitcoin.Term,
@@ -183,7 +185,8 @@ library
                           Simplicity.Inference as Simplicity.Bitcoin.Inference,
                           Simplicity.JetType as Simplicity.Bitcoin.JetType,
                           Simplicity.Serialization.BitString as Simplicity.Bitcoin.Serialization.BitString,
-                          Simplicity.Serialization.ByteString as Simplicity.Bitcoin.Serialization.ByteString)
+                          Simplicity.Serialization.ByteString as Simplicity.Bitcoin.Serialization.ByteString,
+                          Simplicity.StaticAnalysis.Cost as Simplicity.Bitcoin.StaticAnalysis.Cost)
                        requires
                          (Simplicity.Primitive as Simplicity.Bitcoin.Primitive),
                        Simplicity-Indef
@@ -193,7 +196,8 @@ library
                           Simplicity.Inference as Simplicity.Elements.Inference,
                           Simplicity.JetType as Simplicity.Elements.JetType,
                           Simplicity.Serialization.BitString as Simplicity.Elements.Serialization.BitString,
-                          Simplicity.Serialization.ByteString as Simplicity.Elements.Serialization.ByteString)
+                          Simplicity.Serialization.ByteString as Simplicity.Elements.Serialization.ByteString,
+                          Simplicity.StaticAnalysis.Cost as Simplicity.Elements.StaticAnalysis.Cost)
                        requires
                          (Simplicity.Primitive as Simplicity.Elements.Primitive)
   other-extensions:    ConstraintKinds, GADTs, StandaloneDeriving, TypeFamilies


### PR DESCRIPTION
This PR does a couple of related things:

1. Makes the static analysis of memory and CPU bounds available for FFI bindings.
2. Generates expected CPU weight bounds for the generated test vectors.
3. Fixes the witness weight computation in Haskell, which addresses half of #159.