### PR TITLE
GenRustJets: rename `bitcoin_hashes` to `hashes`

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -348,7 +348,7 @@ rustImports mod = vsep (map (<> semi)
   , "use crate::decode_bits"
   , "use crate::{decode, BitIter, BitWriter}"
   , "use crate::analysis::Cost"
-  , "use bitcoin_hashes::sha256::Midstate"
+  , "use hashes::sha256::Midstate"
   , "use simplicity_sys::CFrameItem"
   , "use std::io::Write"
   , "use std::{fmt, str}"


### PR DESCRIPTION
We made this change in rust-simplicity but forgot to update the generated code.