### PR TITLE
Fix GenRustJet's bitcoin.rs

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -159,6 +159,11 @@ showRustHash h = fillSep $ ((<> comma) . format <$> chunksOf 2 str_h)
 rustJetCmr :: Module -> Doc a
 rustJetCmr mod = vsep $
   [ nest 4 (vsep ("fn cmr(&self) -> Cmr {" :
+-- Temporarily if statment until Bitcoin Jets have weight costs assigned to them
+-- See Haskell/Simplicity/Bitcoin/Jets.hs:  jetCost (BitcoinJet jt) = error "Simplicity.Bitcoin.Jets.jetCost: :TODO: Implement jets for Bitcoin and benchmark them."
+   if Just "Bitcoin" == moduleName mod
+   then ["unimplemented!(\"Bitcoin jet CMRs weights have not yet been implemented.\")"]
+   else
     [ nest 4 (vsep ("let bytes = match self {" :
         map (<>comma)
         [ nest 4 (vsep


### PR DESCRIPTION
Recently jet weights were incorporated into their CMR hash. However Bitcoin jet weights do not exist at the moment. Temporarily disable the CMR calculation of Bitcoin jets for Rust.