### PR TITLE
Revamp radix sort

### DIFF
--- a/C/rsort.h
+++ b/C/rsort.h
@@ -8,13 +8,6 @@
 
 #include "limitations.h"
 #include "sha256.h"
-#include "simplicity_assert.h"
-
-_Static_assert(UCHAR_MAX < SIZE_MAX, "UCHAR_MAX >= SIZE_MAX");
-#define CHAR_COUNT ((size_t)1 << CHAR_BIT)
-
-/* Internal function used by 'hasDuplicates'.  Do not call directly. */
-const sha256_midstate* rsort(const sha256_midstate** a, size_t len, uint32_t* stack);
 
 /* Searches for duplicates in an array of 'sha256_midstate's.
  * If malloc fails, returns -1.
@@ -24,27 +17,6 @@ const sha256_midstate* rsort(const sha256_midstate** a, size_t len, uint32_t* st
  * Precondition: const sha256_midstate a[len];
  *               len <= DAG_LEN_MAX;
  */
-static inline int hasDuplicates(const sha256_midstate* a, uint_fast32_t len) {
-  if (len < 2) return 0;
-  static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding.");
-  static_assert(DAG_LEN_MAX <= UINT32_MAX, "DAG_LEN_MAX does not fit in uint32_t.");
-  static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(const sha256_midstate*), "perm array too large.");
-  simplicity_assert(len <= SIZE_MAX / sizeof(const sha256_midstate*));
-  const sha256_midstate **perm = malloc(len * sizeof(const sha256_midstate*));
-  uint32_t *stack = malloc(((CHAR_COUNT - 1)*(sizeof((*perm)->s)) + 1) * sizeof(uint32_t));
-  int result = perm && stack ? 0 : -1;
-
-  if (0 <= result) {
-    for (uint_fast32_t i = 0; i < len; ++i) {
-      perm[i] = a + i;
-    }
-
-    result = NULL != rsort(perm, len, stack);
-  }
-
-  free(perm);
-  free(stack);
-  return result;
-}
+int hasDuplicates(const sha256_midstate* a, uint_fast32_t len);
 
 #endif

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -9,6 +9,22 @@
 #include "limitations.h"
 #include "sha256.h"
 
+/* Sorts an array of pointers to 'sha256_midstate's in place in memcmp order.
+ * If malloc fails, returns false.
+ * Otherwise, returns true.
+ *
+ * The time complexity of rsort is O('len').
+ *
+ * We are sorting in memcmp order, which is the lexicographical order of the object representation, i.e. the order that one
+ * gets when casting 'sha256_midstate' to a 'unsigned char[]'. This representation is implementation defined, and will differ
+ * on big endian and little endian architectures.
+ *
+ * It is critical that the details of this order remain unobservable from the consensus rules.
+ *
+ * Precondition: For all 0 <= i < len, NULL != a[i];
+ */
+bool rsort(const sha256_midstate** a, uint_fast32_t len);
+
 /* Searches for duplicates in an array of 'sha256_midstate's.
  * If malloc fails, returns -1.
  * If no duplicates are found, returns 0.

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -14,7 +14,7 @@ _Static_assert(UCHAR_MAX < SIZE_MAX, "UCHAR_MAX >= SIZE_MAX");
 #define CHAR_COUNT ((size_t)1 << CHAR_BIT)
 
 /* Internal function used by 'hasDuplicates'.  Do not call directly. */
-const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t len, size_t level);
+const sha256_midstate* rsort(const sha256_midstate** a, size_t len, uint32_t* stack);
 
 /* Searches for duplicates in an array of 'sha256_midstate's.
  * If malloc fails, returns -1.
@@ -24,30 +24,26 @@ const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t 
  * Precondition: const sha256_midstate a[len];
  *               len <= DAG_LEN_MAX;
  */
-static inline int hasDuplicates(const sha256_midstate* a, size_t len) {
-  if (0 == len) return 0;
+static inline int hasDuplicates(const sha256_midstate* a, uint_fast32_t len) {
+  if (len < 2) return 0;
   static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding.");
-  static_assert(sizeof(a->s) < SIZE_MAX / CHAR_COUNT, "CHAR_BIT is way too large.");
-  static_assert((sizeof(a->s) + 1) * CHAR_COUNT <= SIZE_MAX/sizeof(size_t), "sizeof(size_t) is way too large.");
-  size_t * scratch = malloc((sizeof(a->s) + 1) * CHAR_COUNT * sizeof(size_t));
+  static_assert(DAG_LEN_MAX <= UINT32_MAX, "DAG_LEN_MAX does not fit in uint32_t.");
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(const sha256_midstate*), "perm array too large.");
-  static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
-  static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "perm array index does not fit in uint32_t.");
   simplicity_assert(len <= SIZE_MAX / sizeof(const sha256_midstate*));
-  simplicity_assert(len - 1 <= UINT32_MAX);
   const sha256_midstate **perm = malloc(len * sizeof(const sha256_midstate*));
-  int result = scratch && perm ? 0 : -1;
+  uint32_t *stack = malloc(((CHAR_COUNT - 1)*(sizeof((*perm)->s)) + 1) * sizeof(uint32_t));
+  int result = perm && stack ? 0 : -1;
 
   if (0 <= result) {
-    for (size_t i = 0; i < len; ++i) {
+    for (uint_fast32_t i = 0; i < len; ++i) {
       perm[i] = a + i;
     }
 
-    result = NULL != rsort(scratch, perm, len, 0);
+    result = NULL != rsort(perm, len, stack);
   }
 
   free(perm);
-  free(scratch);
+  free(stack);
   return result;
 }
 

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -43,7 +43,7 @@ static inline int hasDuplicates(const sha256_midstate* a, size_t len) {
       perm[i] = a + i;
     }
 
-    result = NULL != rsort(scratch, perm, len, sizeof(a->s));
+    result = NULL != rsort(scratch, perm, len, 0);
   }
 
   free(perm);

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <simplicity/errorCodes.h>
 #include "limitations.h"
 #include "sha256.h"
 #include "simplicity_assert.h"
@@ -26,7 +25,7 @@ const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t 
  *               len <= DAG_LEN_MAX;
  */
 static inline int hasDuplicates(const sha256_midstate* a, size_t len) {
-  if (0 == len) return SIMPLICITY_NO_ERROR;
+  if (0 == len) return 0;
   static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding.");
   static_assert(sizeof(a->s) < SIZE_MAX / CHAR_COUNT, "CHAR_BIT is way too large.");
   static_assert((sizeof(a->s) + 1) * CHAR_COUNT <= SIZE_MAX/sizeof(size_t), "sizeof(size_t) is way too large.");


### PR DESCRIPTION
The new implementation is non-recursive, ~~uses stack instead of heap (approximately 32Kibi),~~ and exposes an rsort function that doesn't abort early like was was used for `hasDuplicates`.

The new rsort functionality will be used to implement the "total-fees" jet which computes the total fees of any given asset id.