### PR TITLE
GenRustJets: ElementsEnv with argument

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -290,6 +290,7 @@ rustJetImpl mod = vsep $
     ]
    where
     env | Nothing <- moduleName mod = "()"
+        | Just "Elements" == moduleName mod = "ElementsEnv<std::sync::Arc<elements::Transaction>>"
         | Just name <- moduleName mod = name ++ "Env"
     cEnv | Just "Elements" == moduleName mod = "CElementsTxEnv"
          | otherwise = "()"


### PR DESCRIPTION
Fixes the Elements environment which now takes a type argument.