### PR TITLE
Fix compatibility with stable nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,12 @@ let hp = nixpkgs.haskell.packages.${ghc};
   haskellPackages = hp.override {
     overrides = self: super: {
       Simplicity = haskell;
+
+      # Temporary work around for compiling hlint and hasktags in ghc94.
+      microlens = self.microlens_0_4_13_1;
+      microlens-ghc = self.microlens-ghc_0_4_14_1;
+      microlens-platform = self.microlens-platform_0_4_3_3;
+      hlint = self.hlint_3_5;
     };
   };
 


### PR DESCRIPTION
`nix-shell` no longer works on nixpkgs 23.05 (latest stable) since 4c32bcf53c59eabc80c97f607754d784b67311db. This PR partially reverts the changes of this commit as a fix.