### PR TITLE
Enable parallel builds in nix derivations

### DIFF
--- a/Simplicity.C.nix
+++ b/Simplicity.C.nix
@@ -13,6 +13,7 @@ assert withCoverage -> gcovr != null && gcov-executable != null;
 stdenv.mkDerivation {
   name = "libSimplicity-0.0.0";
   src = lib.sourceFilesBySuffices ./C ["Makefile" ".c" ".h" ".inc"];
+  enableParallelBuilding = true;
   CPPFLAGS = lib.optional (builtins.isString wideMultiply) "-DUSE_FORCE_WIDEMUL_${lib.toUpper wideMultiply}=1";
   CFLAGS = lib.optional withCoverage "--coverage"
         ++ lib.optional production "-DPRODUCTION";

--- a/Simplicity.Haskell.nix
+++ b/Simplicity.Haskell.nix
@@ -14,6 +14,7 @@ mkDerivation (rec {
   libraryHaskellDepends = [ base binary cereal lens-family MemoTrie mtl split tardis unification-fd vector ];
   executableHaskellDepends = [ prettyprinter ];
   testHaskellDepends = libraryHaskellDepends ++ [ QuickCheck tasty tasty-hunit tasty-quickcheck ];
+  enableParallelBuilding = true;
   preCheck = ''
     export GHCRTS=-N$NIX_BUILD_CORES
   '';


### PR DESCRIPTION
Parallel builds make nix derivations faster. If the computer gets too slow, then the number of available CPU cores can be manually lowered.