### PR TITLE
Refactor name generation

### DIFF
--- a/Haskell-Generate/NameWrangler.hs
+++ b/Haskell-Generate/NameWrangler.hs
@@ -1,0 +1,28 @@
+module NameWrangler
+  ( upperSnakeCase
+  , lowerSnakeCase
+  , mkName
+  ) where
+
+import Data.Char (isAlpha, isDigit, isUpper, toLower, toUpper)
+import Data.List (groupBy, intercalate)
+import Data.List.Split (condense, dropInitBlank, keepDelimsL, split, splitOn, whenElt)
+
+snakeCase :: String -> String
+snakeCase str = intercalate "_" . groupSingles $ (split . keepDelimsL . dropInitBlank . whenElt) isUpper =<< splitDigit =<< splitOn "_" str
+ where
+  splitDigit = (split . condense . whenElt) isDigit
+  groupSingles = map concat . groupBy singles
+   where
+    singles [x] [y] = isAlpha x && isAlpha y
+    singles _ _ = False
+
+upperSnakeCase :: String -> String
+upperSnakeCase = map toUpper . snakeCase
+
+lowerSnakeCase :: String -> String
+lowerSnakeCase = map toLower . snakeCase
+
+mkName :: Show a => a -> String
+mkName = filter (`notElem` "()") . last . words . show
+

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -273,6 +273,7 @@ executable GenPrimitive
     -- other-extensions:
     hs-source-dirs:   Haskell-Generate
     default-language: Haskell2010
+    other-modules:    NameWrangler
     build-depends:    Simplicity,
                       base >=4.9 && <4.18,
                       containers >=0.5.10 && <0.7,
@@ -309,6 +310,7 @@ executable GenRustJets
     -- other-extensions:
     hs-source-dirs:   Haskell-Generate
     default-language: Haskell2010
+    other-modules:    NameWrangler
     other-extensions: OverloadedStrings
     build-depends:    Simplicity,
                       base >=4.9 && <4.18,


### PR DESCRIPTION
At the same time we generalize it to support names with underscores, which we will be soon adding.

This PR doesn't change the current output of GenPrimitives or GenRustJets.