### PR TITLE
Rename bitstream errors

### DIFF
--- a/C/bitstream.c
+++ b/C/bitstream.c
@@ -5,17 +5,17 @@
 #include "simplicity_assert.h"
 
 /* Closes a bitstream by consuming all remaining bits.
- * Returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES' if CHAR_BIT or more bits remain in the stream.
+ * Returns 'SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES' if CHAR_BIT or more bits remain in the stream.
  * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING' if any remaining bits are non-zero.
  * Otherwise returns 'SIMPLICITY_NO_ERROR'.
  *
  * Precondition: NULL != stream
  */
 simplicity_err closeBitstream(bitstream* stream) {
-  if (1 < stream->len) return SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES;        /* If there is more than one byte remaining. */
+  if (1 < stream->len) return SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES;        /* If there is more than one byte remaining. */
   if (1 == stream->len) {
-    if (0 == stream->offset) return SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES;  /* If there is one byte remaining */
-    if (0 != (*stream->arr & (UCHAR_MAX >> stream->offset))) {              /* If any of the unconsumed bits are non-zero */
+    if (0 == stream->offset) return SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES;  /* If there is one byte remaining */
+    if (0 != (*stream->arr & (UCHAR_MAX >> stream->offset))) {                /* If any of the unconsumed bits are non-zero */
       return SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING;
     }
   }

--- a/C/bitstream.c
+++ b/C/bitstream.c
@@ -6,7 +6,7 @@
 
 /* Closes a bitstream by consuming all remaining bits.
  * Returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES' if CHAR_BIT or more bits remain in the stream.
- * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS' if any remaining bits are non-zero.
+ * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING' if any remaining bits are non-zero.
  * Otherwise returns 'SIMPLICITY_NO_ERROR'.
  *
  * Precondition: NULL != stream
@@ -16,7 +16,7 @@ simplicity_err closeBitstream(bitstream* stream) {
   if (1 == stream->len) {
     if (0 == stream->offset) return SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES;  /* If there is one byte remaining */
     if (0 != (*stream->arr & (UCHAR_MAX >> stream->offset))) {              /* If any of the unconsumed bits are non-zero */
-      return SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS;
+      return SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING;
     }
   }
   /* Otherwise there are either 0 bits remaining or there are between 1 and CHAR_BITS-1 bits remaining and they are all zero. */

--- a/C/bitstream.h
+++ b/C/bitstream.h
@@ -30,7 +30,7 @@ static inline bitstream initializeBitstream(const unsigned char* arr, size_t len
 }
 
 /* Closes a bitstream by consuming all remaining bits.
- * Returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES' if CHAR_BIT or more bits remain in the stream.
+ * Returns 'SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES' if CHAR_BIT or more bits remain in the stream.
  * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING' if any remaining bits are non-zero.
  * Otherwise returns 'SIMPLICITY_NO_ERROR'.
  *

--- a/C/bitstream.h
+++ b/C/bitstream.h
@@ -31,7 +31,7 @@ static inline bitstream initializeBitstream(const unsigned char* arr, size_t len
 
 /* Closes a bitstream by consuming all remaining bits.
  * Returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES' if CHAR_BIT or more bits remain in the stream.
- * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS' if any remaining bits are non-zero.
+ * Otherwise, returns 'SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING' if any remaining bits are non-zero.
  * Otherwise returns 'SIMPLICITY_NO_ERROR'.
  *
  * Precondition: NULL != stream

--- a/C/dag.c
+++ b/C/dag.c
@@ -464,7 +464,7 @@ simplicity_err verifyCanonicalOrder(dag_node* dag, const size_t len) {
  * For each 'WITNESS' : A |- B expression in 'dag', the bits from the 'witness' bitstring are decoded in turn
  * to construct a compact representation of a witness value of type B.
  * This function only returns 'SIMPLICITY_NO_ERROR' when exactly 'witness.len' bits are consumed by all the 'dag's witness values.
- * If extra bits remain, then 'SIMPLICITY_ERR_WITNESS_UNUSED_BITS' is returned.
+ * If extra bits remain, then 'SIMPLICITY_ERR_WITNESS_TRAILING_BITS' is returned.
  * If there are not enough bits, then 'SIMPLICITY_ERR_WITNESS_EOF' is returned.
  *
  * Note: the 'witness' value is passed by copy because the implementation manipulates a local copy of the structure.
@@ -549,7 +549,7 @@ simplicity_err fillWitnessData(dag_node* dag, type* type_dag, const size_t len, 
       }
     }
   }
-  return 0 == witness.len ? SIMPLICITY_NO_ERROR : SIMPLICITY_ERR_WITNESS_UNUSED_BITS;
+  return 0 == witness.len ? SIMPLICITY_NO_ERROR : SIMPLICITY_ERR_WITNESS_TRAILING_BITS;
 }
 
 /* Verifies that identity Merkle roots of every subexpression in a well-typed 'dag' with witnesses are all unique,

--- a/C/dag.h
+++ b/C/dag.h
@@ -365,7 +365,7 @@ simplicity_err verifyCanonicalOrder(dag_node* dag, const size_t len);
  * For each 'WITNESS' : A |- B expression in 'dag', the bits from the 'witness' bitstring are decoded in turn
  * to construct a compact representation of a witness value of type B.
  * This function only returns 'SIMPLICITY_NO_ERROR' when exactly 'witness.len' bits are consumed by all the 'dag's witness values.
- * If extra bits remain, then 'SIMPLICITY_ERR_WITNESS_UNUSED_BITS' is returned.
+ * If extra bits remain, then 'SIMPLICITY_ERR_WITNESS_TRAILING_BITS' is returned.
  * If there are not enough bits, then 'SIMPLICITY_ERR_WITNESS_EOF' is returned.
  *
  * Precondition: dag_node dag[len] and 'dag' without witness data and is well-typed with 'type_dag';

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -20,7 +20,7 @@ typedef enum {
   SIMPLICITY_ERR_STOP_CODE = -10,
   SIMPLICITY_ERR_HIDDEN = -12,
   SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES = -14,
-  SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS = -16,
+  SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING = -16,
   SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION = -18,
   SIMPLICITY_ERR_TYPE_INFERENCE_OCCURS_CHECK = -20,
   SIMPLICITY_ERR_TYPE_INFERENCE_NOT_PROGRAM = -22,
@@ -69,8 +69,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Program has illegal HIDDEN child node";
   case SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES:
     return "Unused bytes at the end of the program";
-  case SIMPLICITY_ERR_BITSTREAM_UNUSED_BITS:
-    return "Unused bits at the end of the program";
+  case SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING:
+    return "Illegal padding in final byte of program";
   case SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION:
     return "Unification failure";
   case SIMPLICITY_ERR_TYPE_INFERENCE_OCCURS_CHECK:

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -25,7 +25,7 @@ typedef enum {
   SIMPLICITY_ERR_TYPE_INFERENCE_OCCURS_CHECK = -20,
   SIMPLICITY_ERR_TYPE_INFERENCE_NOT_PROGRAM = -22,
   SIMPLICITY_ERR_WITNESS_EOF = -24,
-  SIMPLICITY_ERR_WITNESS_UNUSED_BITS = -26,
+  SIMPLICITY_ERR_WITNESS_TRAILING_BITS = -26,
   SIMPLICITY_ERR_UNSHARED_SUBEXPRESSION = -28,
   SIMPLICITY_ERR_CMR = -30,
   SIMPLICITY_ERR_AMR = -32,
@@ -79,8 +79,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Expression not unit to unit";
   case SIMPLICITY_ERR_WITNESS_EOF:
     return "Unexpected end of witness block";
-  case SIMPLICITY_ERR_WITNESS_UNUSED_BITS:
-    return "Unused data at the end of the witness block";
+  case SIMPLICITY_ERR_WITNESS_TRAILING_BITS:
+    return "Trailing bits after final value of witness block";
   case SIMPLICITY_ERR_UNSHARED_SUBEXPRESSION:
     return "Subexpression not properly shared";
   case SIMPLICITY_ERR_CMR:

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -19,7 +19,7 @@ typedef enum {
   SIMPLICITY_ERR_FAIL_CODE = -8,
   SIMPLICITY_ERR_STOP_CODE = -10,
   SIMPLICITY_ERR_HIDDEN = -12,
-  SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES = -14,
+  SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES = -14,
   SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING = -16,
   SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION = -18,
   SIMPLICITY_ERR_TYPE_INFERENCE_OCCURS_CHECK = -20,
@@ -67,8 +67,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Program has STOP node";
   case SIMPLICITY_ERR_HIDDEN:
     return "Program has illegal HIDDEN child node";
-  case SIMPLICITY_ERR_BITSTREAM_UNUSED_BYTES:
-    return "Unused bytes at the end of the program";
+  case SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES:
+    return "Trailing bytes after final byte of program";
   case SIMPLICITY_ERR_BITSTREAM_ILLEGAL_PADDING:
     return "Illegal padding in final byte of program";
   case SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION:


### PR DESCRIPTION
The new name and error message clarify what the error does.