### PR TITLE
Haskell bindings

### DIFF
--- a/Haskell/Tests/Simplicity/Elements/FFI/Primitive.hs
+++ b/Haskell/Tests/Simplicity/Elements/FFI/Primitive.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Simplicity.Elements.FFI.Primitive
+  ( decodeJetCMR
+  , ErrorCode(..)
+  ) where
+
+import Foreign.C.Types (CInt(..))
+import Foreign.Ptr (Ptr)
+import Foreign.Marshal.Unsafe (unsafeLocalState)
+
+import Simplicity.Digest
+import Simplicity.FFI.Bitstream
+import Simplicity.FFI.Dag
+
+data ErrorCode = BitstreamEof | DataOutOfRange deriving (Eq, Show)
+
+decodeError :: CInt -> Either ErrorCode ()
+decodeError 0 = Right ()
+decodeError (-2) = Left BitstreamEof
+decodeError (-4) = Left DataOutOfRange
+decodeError err = error $ "Simplicity.Elements.FFI.Primitive.decodeError: Unexpected error code " ++ show err
+
+foreign import ccall unsafe "" decodeJet :: Ptr DagNode -> Ptr Bitstream -> IO CInt
+
+decodeJetNode :: Ptr Bitstream -> (Either ErrorCode (Ptr DagNode) -> IO a) -> IO a
+decodeJetNode pstream k =
+  withDagNode $ \pnode -> do
+  error <- decodeJet pnode pstream
+  k (decodeError error >> return pnode)
+
+decodeJetCMR :: [Bool] -> Either ErrorCode Hash256
+decodeJetCMR codeWord = unsafeLocalState $
+  initializeBitstream codeWord $ \pstream ->
+  decodeJetNode pstream $ \result ->
+  case result of
+    Left err -> return $ Left err
+    Right pnode -> Right <$> dagNodeGetCMR pnode

--- a/Haskell/Tests/Simplicity/Elements/Serialization/Tests.hs
+++ b/Haskell/Tests/Simplicity/Elements/Serialization/Tests.hs
@@ -3,16 +3,22 @@ module Simplicity.Elements.Serialization.Tests (tests) where
 
 import Control.Monad (mzero)
 import Data.Foldable (toList)
+import qualified Data.List as List
 import qualified Data.Vector.Unboxed as V
 
+import Simplicity.Arbitrary
+import Simplicity.CoreJets
 import Simplicity.Elements.Jets as Elements
 import Simplicity.Elements.FFI.Primitive as Elements
+import Simplicity.FFI.Dag
 import Simplicity.MerkleRoot
 import Simplicity.Serialization
 import Simplicity.Ty
+import Simplicity.Ty.Word
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@=?), testCase)
+import Test.Tasty.QuickCheck (Property, arbitrary, forAll, chooseInt, testProperty, vectorOf)
 
 -- Run tests comparing Bit Machine execution with Simplicity's denotational semantics using both naive and TCO translation.
 tests :: TestTree
@@ -20,7 +26,8 @@ tests = testGroup "Serialization"
       [ testGroup "Haskell"
         [ testDecodeElementsJet jt | SomeArrow jt@(ElementsJet _) <- toList Elements.jetMap ]
       , testGroup "C"
-        [ testDecodeElementsJetFFI jt | SomeArrow jt <- toList Elements.jetMap ]
+      $ [ testDecodeElementsJetFFI jt | SomeArrow jt <- toList Elements.jetMap ]
+      ++ [ testProperty "prop_wordCMR" prop_wordCMR ]
       ]
 
 testDecodeElementsJet :: (TyC a, TyC b) => Elements.JetType a b -> TestTree
@@ -35,3 +42,14 @@ testDecodeElementsJetFFI jt = testCase (show jt) (Right cmr @=? Elements.decodeJ
   -- All jet encodings should begin with a 1 bit, which we consume.
   True:bitstream = Elements.putJetBit jt []
   cmr = commitmentRoot (asJet jt)
+
+prop_wordCMR :: SomeConstWordContent -> Property
+prop_wordCMR (SomeConstWordContent cwc) = forAll prefix prop
+ where
+  prefix = do
+    n <- chooseInt (0, 7)
+    vectorOf n arbitrary
+  prop l = wordCMR == computeWordCMR (length l) (l ++ stream)
+   where
+    wordCMR = commitmentRoot $ asJet (ConstWordJet cwc)
+    stream = putConstWordValueBit cwc

--- a/Haskell/Tests/Simplicity/Elements/Serialization/Tests.hs
+++ b/Haskell/Tests/Simplicity/Elements/Serialization/Tests.hs
@@ -6,6 +6,8 @@ import Data.Foldable (toList)
 import qualified Data.Vector.Unboxed as V
 
 import Simplicity.Elements.Jets as Elements
+import Simplicity.Elements.FFI.Primitive as Elements
+import Simplicity.MerkleRoot
 import Simplicity.Serialization
 import Simplicity.Ty
 
@@ -15,10 +17,21 @@ import Test.Tasty.HUnit ((@=?), testCase)
 -- Run tests comparing Bit Machine execution with Simplicity's denotational semantics using both naive and TCO translation.
 tests :: TestTree
 tests = testGroup "Serialization"
-      [testDecodeElementsJet jt | SomeArrow jt@(ElementsJet _) <- toList Elements.jetMap]
+      [ testGroup "Haskell"
+        [ testDecodeElementsJet jt | SomeArrow jt@(ElementsJet _) <- toList Elements.jetMap ]
+      , testGroup "C"
+        [ testDecodeElementsJetFFI jt | SomeArrow jt <- toList Elements.jetMap ]
+      ]
 
 testDecodeElementsJet :: (TyC a, TyC b) => Elements.JetType a b -> TestTree
 testDecodeElementsJet jt = testCase (show jt) (Just (SomeArrow jt) @=? decode)
  where
   vector = V.fromList $ Elements.putJetBit jt []
   decode = evalExactVector (Elements.getJetBit mzero) vector
+
+testDecodeElementsJetFFI :: (TyC a, TyC b) => Elements.JetType a b -> TestTree
+testDecodeElementsJetFFI jt = testCase (show jt) (Right cmr @=? Elements.decodeJetCMR bitstream)
+ where
+  -- All jet encodings should begin with a 1 bit, which we consume.
+  True:bitstream = Elements.putJetBit jt []
+  cmr = commitmentRoot (asJet jt)

--- a/Haskell/Tests/Simplicity/FFI/Bitstream.hs
+++ b/Haskell/Tests/Simplicity/FFI/Bitstream.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Simplicity.FFI.Bitstream
+  ( Bitstream
+  , initializeBitstream
+  ) where
+
+import qualified Data.ByteString as BS
+import Data.Serialize (decode)
+import Data.Serialize.Put (runPut)
+import Foreign.C.Types (CSize(..), CChar(..))
+import Foreign.Ptr (Ptr)
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.Marshal.Unsafe (unsafeLocalState)
+import Foreign.Storable (Storable(..))
+
+import Simplicity.Serialization
+
+-- Abstract representative for our C structures.
+newtype Bitstream = Bitstream Bitstream
+
+foreign import ccall unsafe "&" c_sizeof_bitstream :: Ptr CSize
+
+foreign import ccall unsafe "" c_initializeBitstream :: Ptr Bitstream -> Ptr CChar -> CSize -> IO ()
+
+sizeof_bitstream :: Int
+sizeof_bitstream = fromIntegral . unsafeLocalState $ peek c_sizeof_bitstream
+
+initializeBitstream :: [Bool] -> (Ptr Bitstream -> IO a) -> IO a
+initializeBitstream stream k =
+  allocaBytes sizeof_bitstream $ \pstream ->
+  BS.useAsCString bs $ \pbs -> do
+   c_initializeBitstream pstream pbs (fromIntegral len)
+   k pstream
+ where
+  bs = runPut $ putBitStream stream
+  len = length stream

--- a/Haskell/Tests/Simplicity/FFI/Dag.hs
+++ b/Haskell/Tests/Simplicity/FFI/Dag.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Simplicity.FFI.Dag
+  ( DagNode
+  , dagNodeGetCMR
+  , withDagNode
+  ) where
+
+import qualified Data.ByteString as BS
+import Data.Serialize (decode)
+import Data.Serialize.Put (runPut)
+import Foreign.C.Types (CSize(..), CChar(..))
+import Foreign.Ptr (Ptr)
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.Marshal.Array (allocaArray)
+import Foreign.Marshal.Unsafe (unsafeLocalState)
+import Foreign.Storable (Storable(..))
+
+import Simplicity.Digest
+import Simplicity.FFI.Bitstream
+
+-- Abstract representative for our C structures.
+newtype DagNode = DagNode DagNode
+
+foreign import ccall unsafe "&" c_sizeof_dag_node :: Ptr CSize
+
+foreign import ccall unsafe "" c_dag_node_get_cmr :: Ptr CChar -> Ptr DagNode -> IO ()
+
+sizeof_dag_node :: Int
+sizeof_dag_node = fromIntegral . unsafeLocalState $ peek c_sizeof_dag_node
+
+withDagNode :: (Ptr DagNode -> IO a) -> IO a
+withDagNode = allocaBytes sizeof_dag_node
+
+dagNodeGetCMR :: Ptr DagNode -> IO Hash256
+dagNodeGetCMR pnode =
+  allocaArray 32 $ \buf -> do
+  c_dag_node_get_cmr buf pnode
+  Right hash <- decode <$> BS.packCStringLen (buf, 32)
+  return hash

--- a/Haskell/cbits/bitstream.c
+++ b/Haskell/cbits/bitstream.c
@@ -1,0 +1,7 @@
+#include "bitstream.h"
+
+const size_t c_sizeof_bitstream = sizeof(bitstream);
+
+void c_initializeBitstream(bitstream *result, const unsigned char* arr, size_t len) {
+  *result = initializeBitstream(arr, len);
+}

--- a/Haskell/cbits/dag.c
+++ b/Haskell/cbits/dag.c
@@ -1,0 +1,7 @@
+#include "dag.h"
+
+const size_t c_sizeof_dag_node = sizeof(dag_node);
+
+void c_dag_node_get_cmr(unsigned char *cmr, const dag_node* node) {
+  sha256_fromMidstate(cmr, node->cmr.s);
+}

--- a/Haskell/cbits/dag.c
+++ b/Haskell/cbits/dag.c
@@ -1,6 +1,17 @@
 #include "dag.h"
+#include "bitstream.h"
+#include "bitstring.h"
 
 const size_t c_sizeof_dag_node = sizeof(dag_node);
+
+void c_compute_word_cmr(unsigned char *cmr, bitstream* stream, size_t offset, size_t n) {
+  sha256_midstate result;
+  bitstring value;
+  readBitstring(&value, offset, stream); /* skip offset many bits. */
+  readBitstring(&value, (size_t)1 << n, stream);
+  result = computeWordCMR(&value, n);
+  sha256_fromMidstate(cmr, result.s);
+}
 
 void c_dag_node_get_cmr(unsigned char *cmr, const dag_node* node) {
   sha256_fromMidstate(cmr, node->cmr.s);

--- a/Simplicity.Haskell.nix
+++ b/Simplicity.Haskell.nix
@@ -5,12 +5,8 @@ mkDerivation (rec {
   src = lib.sourceFilesBySuffices
       (lib.sourceByRegex ./. ["^LICENSE$" "^Simplicity\.cabal$" "^Setup.hs$" "^Tests.hs$" "^Haskell$" "^Haskell/.*"
                               "^Haskell-Generate$" "^Haskell-Generate/.*"
-                              "^C$" "^C/uword.h" "^C/bitstring.h" "^C/frame.*" "^C/jets.*" "^C/sha256.*" "^C/simplicity_assert.h"
-                              "^C/precomputed.h" "^C/prefix.h"
-                              "^C/jets-secp256k1.c$" "^C/secp256k1$" "^C/secp256k1/.*"
-                              "^C/include$" "^C/include/simplicity$" "^C/include/simplicity/elements$" "^C/include/simplicity/elements/env.h"
-                              "^C/primitive$" "^C/primitive/elements$" "^C/primitive/elements/jets.*" "^C/primitive/elements/ops.*" "^C/primitive/elements/primitive.*" "^C/primitive/elements/env.c"])
-    ["LICENSE" ".cabal" ".hs" ".hsig" ".h" ".c"];
+                              "^C$" "^C/.*"])
+    ["LICENSE" ".cabal" ".hs" ".hsig" ".h" ".c" ".inc"];
   libraryHaskellDepends = [ base binary cereal lens-family MemoTrie mtl split tardis unification-fd vector ];
   executableHaskellDepends = [ prettyprinter ];
   testHaskellDepends = libraryHaskellDepends ++ [ QuickCheck tasty tasty-hunit tasty-quickcheck ];

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -226,6 +226,8 @@ Test-Suite testsuite
                        Simplicity.Arbitrary, Simplicity.Ty.Arbitrary, Simplicity.Elements.Arbitrary,
                        Simplicity.BitMachine.StaticAnalysis.Tests, Simplicity.BitMachine.Tests,
                        Simplicity.Bitcoin.Serialization.Tests,
+                       Simplicity.FFI.Bitstream, Simplicity.FFI.Dag,
+                       Simplicity.Elements.FFI.Primitive,
                        Simplicity.Elements.TestEval, Simplicity.Elements.Tests, Simplicity.Elements.FFI.Tests,
                        Simplicity.Elements.Serialization.Tests,
                        Simplicity.FFI.Tests,
@@ -233,6 +235,8 @@ Test-Suite testsuite
                        Simplicity.Serialization.Tests,
                        Simplicity.TestCoreEval,
                        Simplicity.Ty.Tests
+  C-sources:           C/primitive/elements/primitive.c, C/bitstream.c
+                       Haskell/cbits/bitstream.c, Haskell/cbits/dag.c
   build-depends:       Simplicity,
                        base >=4.9 && <4.18,
                        bytestring >=0.10 && <0.12,

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -235,7 +235,7 @@ Test-Suite testsuite
                        Simplicity.Serialization.Tests,
                        Simplicity.TestCoreEval,
                        Simplicity.Ty.Tests
-  C-sources:           C/primitive/elements/primitive.c, C/bitstream.c
+  C-sources:           C/rsort.c, C/dag.c, C/primitive/elements/primitive.c, C/bitstream.c
                        Haskell/cbits/bitstream.c, Haskell/cbits/dag.c
   build-depends:       Simplicity,
                        base >=4.9 && <4.18,


### PR DESCRIPTION
Add Haskell FFI bindings to C's `decodeJet` and `computWordCMR`, and then add Haskell tests of these FFI functions