### PR TITLE
Only process local files with gcov

### DIFF
--- a/Simplicity.C.nix
+++ b/Simplicity.C.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, gcovr ? null, wideMultiply ? null, withCoverage ? false
 , production ? false
-, gcov-executable ? if stdenv.cc.isGNU then "gcov" else
+, gcov-executable ? if stdenv.cc.isGNU then "gcov -r" else
                     if stdenv.cc.isClang then "${stdenv.cc.cc.libllvm}/bin/llvm-cov gcov"
                     else null
 , doCheck ? true


### PR DESCRIPTION
The 23.11 release of NixOS has caused GCC to mangle `__FILE__` names withing the nix-store.  See <https://github.com/NixOS/nixpkgs/pull/255192>.  This causes gcov to fail with file-not-found errors:

    (DEBUG) Running gcov: 'gcov /build/source/rsort.gcda --branch-counts --branch-probabilities --demangled-names --hash-filenames --object-directory /build/source' in '/build/source'
    (ERROR) GCOV produced the following errors processing /build/source/rsort.gcda:
            Cannot open source file /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-glibc-2.38-27-dev/include/bits/string_fortified.h

To work around this issue we add the --relative-only flag to gcov instucting it to not consider files with absoulte paths, thus excluding header files in the nix-store.

Note: these files were already filtered out by gcovr, so the resulting documentation hasn't really changed.