### PR TITLE
Fix C headers

### DIFF
--- a/C/bitstring.h
+++ b/C/bitstring.h
@@ -2,6 +2,8 @@
 #ifndef SIMPLICITY_BITSTRING_H
 #define SIMPLICITY_BITSTRING_H
 
+#include <stddef.h>
+#include <stdint.h>
 #include <limits.h>
 #include <stdbool.h>
 #include "simplicity_assert.h"

--- a/C/limitations.h
+++ b/C/limitations.h
@@ -1,6 +1,8 @@
 #ifndef SIMPLICITY_LIMITATIONS_H
 #define SIMPLICITY_LIMITATIONS_H
 
+#include <stdint.h>
+
 #define DAG_LEN_MAX 8000000U
 #define NUMBER_OF_TYPENAMES_MAX 0x1000U
 #define CELLS_MAX 0x500000U /* 5120 Kibibits ought to be enough for anyone. */


### PR DESCRIPTION
I used a bash script to detect C headers with incomplete dependencies. We could add it to the repo if you want.

The script can be run inside `nix-shell --arg coq false --arg haskell false` from the project root.

```bash
compile_header() {
    # Relative header path without leading ./
    local header="${1#./}"
    
    echo "#include \"$header\"" > "tmp.c"

    if ! "$CC" -c "tmp.c" -I include -o /tmp/dummy_out; then
        exit 1
    fi
}

# Make `compile_header` available for `find`
export -f compile_header

cd C
# Compile each header and quit on the first failure
# Exclude secp256k1 directory
find . -path "./secp256k1" -prune -o -name "*.h" \( -exec bash -c 'compile_header "$0"' {} \; -o -quit \)
rm tmp.c
cd ..
```