### PR TITLE
ci: add cross platform cargo build to emulate rust-simplicity build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  c-build:
+    name: C build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust:
+          - stable
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: run build
+        shell: bash
+        run: |
+            cd C
+            cat > Cargo.toml<< EOF
+            [package]
+            name = "ci"
+            version = "0.1.0"
+            edition = "2018"
+            [build-dependencies]
+            cc = "1"
+            EOF
+            mkdir src
+            echo "fn main(){}" > src/main.rs
+            cat > build.rs<< EOF
+            extern crate cc;
+            use std::path::Path;
+            fn main() {
+                let simplicity_path = Path::new(".");
+                let files: Vec<_> = vec![
+                    "bitstream.c",
+                    "dag.c",
+                    "deserialize.c",
+                    "eval.c",
+                    "frame.c",
+                    "jets.c",
+                    "jets-secp256k1.c",
+                    "rsort.c",
+                    "sha256.c",
+                    "type.c",
+                    "typeInference.c",
+                    "primitive/elements/env.c",
+                    "primitive/elements/ops.c",
+                    "primitive/elements/exec.c",
+                    "primitive/elements/jets.c",
+                    "primitive/elements/primitive.c",
+                ]
+                .into_iter()
+                .map(|x| simplicity_path.join(x))
+                .collect();
+                let test_files: Vec<_> = vec![
+                    // "test.c",
+                    "ctx8Pruned.c",
+                    "ctx8Unpruned.c",
+                    "hashBlock.c",
+                    "schnorr0.c",
+                    "schnorr6.c",
+                    "primitive/elements/checkSigHashAllTx1.c",
+                ]
+                .into_iter()
+                .map(|x| simplicity_path.join(x))
+                .collect();
+                let include = simplicity_path.join("include");
+
+                cc::Build::new()
+                    .std("c11")
+                    .flag_if_supported("-fno-inline-functions")
+                    .files(files)
+                    .files(test_files)
+                    // .file(Path::new("depend/wrapper.c"))
+                    // .file(Path::new("depend/env.c"))
+                    .include(include)
+                    .compile("simplicity.a");
+            }
+            EOF
+            cargo build


### PR DESCRIPTION
This is a new github action to reproduce the windows compilation errors experienced downstream in rust-simplicity BlockstreamResearch/rust-simplicity#186  

See the example action run here: https://github.com/delta1/simplicity/actions/runs/7275339523/job/19823056099 

Forgive me for using rust and writing the files from within the action - I wanted to replicate the exact way the build is done in rust-simplicity (barring `env.c` and `wrapper.c` for now), and I didn't want to add a bunch of unrelated files to your C source. 

When I can I will try assist with fixing the windows compilation errors. 