### PR TITLE
build(windows): fix compilation errors on MSVC

### DIFF
--- a/C/bounded.h
+++ b/C/bounded.h
@@ -7,7 +7,7 @@
 typedef uint_least32_t ubounded;
 #define UBOUNDED_MAX UINT32_MAX
 
-static inline ubounded max(ubounded x, ubounded y) {
+static inline ubounded bounded_max(ubounded x, ubounded y) {
   return x <= y ? y : x;
 }
 
@@ -27,8 +27,8 @@ static inline void bounded_inc(ubounded* x) {
  * 'pad( true, a, b)' computes the PADR(a, b) function.
  */
 static inline ubounded pad(bool right, ubounded a, ubounded b) {
-  return max(a, b) - (right ? b : a);
+  return bounded_max(a, b) - (right ? b : a);
 }
 
-static const ubounded overhead = 100 /* milli weight units */;
+enum { overhead = 100 }; /* milli weight units */
 #endif

--- a/C/eval.c
+++ b/C/eval.c
@@ -607,21 +607,21 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
      case ASSERTL:
      case ASSERTR:
      case CASE:
-      bound[i].extraCellsBound[0] = max( bound[dag[i].child[0]].extraCellsBound[0]
+      bound[i].extraCellsBound[0] = bounded_max( bound[dag[i].child[0]].extraCellsBound[0]
                                        , bound[dag[i].child[1]].extraCellsBound[0] );
-      bound[i].extraCellsBound[1] = max( bound[dag[i].child[0]].extraCellsBound[1]
+      bound[i].extraCellsBound[1] = bounded_max( bound[dag[i].child[0]].extraCellsBound[1]
                                        , bound[dag[i].child[1]].extraCellsBound[1] );
 
-      bound[i].extraUWORDBound[0] = max( bound[dag[i].child[0]].extraUWORDBound[0]
+      bound[i].extraUWORDBound[0] = bounded_max( bound[dag[i].child[0]].extraUWORDBound[0]
                                        , bound[dag[i].child[1]].extraUWORDBound[0] );
-      bound[i].extraUWORDBound[1] = max( bound[dag[i].child[0]].extraUWORDBound[1]
+      bound[i].extraUWORDBound[1] = bounded_max( bound[dag[i].child[0]].extraUWORDBound[1]
                                        , bound[dag[i].child[1]].extraUWORDBound[1] );
 
-      bound[i].extraFrameBound[0] = max( bound[dag[i].child[0]].extraFrameBound[0]
+      bound[i].extraFrameBound[0] = bounded_max( bound[dag[i].child[0]].extraFrameBound[0]
                                        , bound[dag[i].child[1]].extraFrameBound[0] );
-      bound[i].extraFrameBound[1] = max( bound[dag[i].child[0]].extraFrameBound[1]
+      bound[i].extraFrameBound[1] = bounded_max( bound[dag[i].child[0]].extraFrameBound[1]
                                        , bound[dag[i].child[1]].extraFrameBound[1] );
-      bound[i].cost = bounded_add(overhead, max( bound[dag[i].child[0]].cost
+      bound[i].cost = bounded_add(overhead, bounded_max( bound[dag[i].child[0]].cost
                                                , bound[dag[i].child[1]].cost ));
       break;
      case DISCONNECT:
@@ -632,20 +632,20 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
         bound[i].extraCellsBound[1] = UBOUNDED_MAX;
       } else {
         bound[i].extraCellsBound[1] = type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize;
-        bound[i].extraCellsBound[0] = max(
+        bound[i].extraCellsBound[0] = bounded_max(
           bounded_add( type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize
-                     , max( bounded_add(bound[i].extraCellsBound[1], bound[dag[i].child[0]].extraCellsBound[1])
-                          , max(bound[dag[i].child[0]].extraCellsBound[0], bound[dag[i].child[1]].extraCellsBound[1]))),
+                     , bounded_max( bounded_add(bound[i].extraCellsBound[1], bound[dag[i].child[0]].extraCellsBound[1])
+                          , bounded_max(bound[dag[i].child[0]].extraCellsBound[0], bound[dag[i].child[1]].extraCellsBound[1]))),
           bound[dag[i].child[1]].extraCellsBound[0]);
       }
       bound[i].extraUWORDBound[1] = (ubounded)ROUND_UWORD(type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize);
-      bound[i].extraUWORDBound[0] = max(
+      bound[i].extraUWORDBound[0] = bounded_max(
           (ubounded)ROUND_UWORD(type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize) +
-          max( bound[i].extraUWORDBound[1] + bound[dag[i].child[0]].extraUWORDBound[1]
-             , max(bound[dag[i].child[0]].extraUWORDBound[0], bound[dag[i].child[1]].extraUWORDBound[1])),
+          bounded_max( bound[i].extraUWORDBound[1] + bound[dag[i].child[0]].extraUWORDBound[1]
+             , bounded_max(bound[dag[i].child[0]].extraUWORDBound[0], bound[dag[i].child[1]].extraUWORDBound[1])),
         bound[dag[i].child[1]].extraUWORDBound[0]);
 
-      bound[i].extraFrameBound[1] = max( bound[dag[i].child[0]].extraFrameBound[1] + 1
+      bound[i].extraFrameBound[1] = bounded_max( bound[dag[i].child[0]].extraFrameBound[1] + 1
                                        , bound[dag[i].child[1]].extraFrameBound[1]);
       bound[i].extraFrameBound[0] = bound[i].extraFrameBound[1] + 1;
       bound[i].cost = bounded_add(overhead
@@ -661,24 +661,24 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
         bound[i].extraCellsBound[0] = UBOUNDED_MAX;
         bound[i].extraCellsBound[1] = UBOUNDED_MAX;
       } else {
-        bound[i].extraCellsBound[0] = max( bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
-                                                      , max( bound[dag[i].child[0]].extraCellsBound[0]
+        bound[i].extraCellsBound[0] = bounded_max( bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
+                                                      , bounded_max( bound[dag[i].child[0]].extraCellsBound[0]
                                                            , bound[dag[i].child[1]].extraCellsBound[1] ))
                                          , bound[dag[i].child[1]].extraCellsBound[0] );
         bound[i].extraCellsBound[1] = bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
                                                  , bound[dag[i].child[0]].extraCellsBound[1] );
       }
-      bound[i].extraUWORDBound[0] = max( (ubounded)ROUND_UWORD(type_dag[COMP_B(dag, type_dag, i)].bitSize) +
-                                         max( bound[dag[i].child[0]].extraUWORDBound[0]
+      bound[i].extraUWORDBound[0] = bounded_max( (ubounded)ROUND_UWORD(type_dag[COMP_B(dag, type_dag, i)].bitSize) +
+                                         bounded_max( bound[dag[i].child[0]].extraUWORDBound[0]
                                             , bound[dag[i].child[1]].extraUWORDBound[1] )
                                        , bound[dag[i].child[1]].extraUWORDBound[0] );
       bound[i].extraUWORDBound[1] = (ubounded)ROUND_UWORD(type_dag[COMP_B(dag, type_dag, i)].bitSize)
                                   + bound[dag[i].child[0]].extraUWORDBound[1];
 
-      bound[i].extraFrameBound[0] = max( bound[dag[i].child[0]].extraFrameBound[0]
+      bound[i].extraFrameBound[0] = bounded_max( bound[dag[i].child[0]].extraFrameBound[0]
                                        , bound[dag[i].child[1]].extraFrameBound[1] )
                                   + 1;
-      bound[i].extraFrameBound[1] = max( bound[dag[i].child[0]].extraFrameBound[1] + 1
+      bound[i].extraFrameBound[1] = bounded_max( bound[dag[i].child[0]].extraFrameBound[1] + 1
                                        , bound[dag[i].child[1]].extraFrameBound[1] );
       bound[i].cost = bounded_add(overhead
                     , bounded_add(type_dag[COMP_B(dag, type_dag, i)].bitSize
@@ -686,18 +686,18 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
       break;
      case PAIR:
       bound[i].extraCellsBound[0] = bound[dag[i].child[1]].extraCellsBound[0];
-      bound[i].extraCellsBound[1] = max( bound[dag[i].child[0]].extraCellsBound[0]
-                                       , max( bound[dag[i].child[0]].extraCellsBound[1]
+      bound[i].extraCellsBound[1] = bounded_max( bound[dag[i].child[0]].extraCellsBound[0]
+                                       , bounded_max( bound[dag[i].child[0]].extraCellsBound[1]
                                             , bound[dag[i].child[1]].extraCellsBound[1] ));
 
       bound[i].extraUWORDBound[0] = bound[dag[i].child[1]].extraUWORDBound[0];
-      bound[i].extraUWORDBound[1] = max( bound[dag[i].child[0]].extraUWORDBound[0]
-                                       , max( bound[dag[i].child[0]].extraUWORDBound[1]
+      bound[i].extraUWORDBound[1] = bounded_max( bound[dag[i].child[0]].extraUWORDBound[0]
+                                       , bounded_max( bound[dag[i].child[0]].extraUWORDBound[1]
                                             , bound[dag[i].child[1]].extraUWORDBound[1] ));
 
-      bound[i].extraFrameBound[0] = max( bound[dag[i].child[0]].extraFrameBound[0]
+      bound[i].extraFrameBound[0] = bounded_max( bound[dag[i].child[0]].extraFrameBound[0]
                                        , bound[dag[i].child[1]].extraFrameBound[0] );
-      bound[i].extraFrameBound[1] = max( bound[dag[i].child[0]].extraFrameBound[0]
+      bound[i].extraFrameBound[1] = bounded_max( bound[dag[i].child[0]].extraFrameBound[0]
                                        , bound[dag[i].child[1]].extraFrameBound[1] );
       bound[i].cost = bounded_add(overhead, bounded_add( bound[dag[i].child[0]].cost
                                                        , bound[dag[i].child[1]].cost ));
@@ -737,10 +737,10 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
     const ubounded inputSize = type_dag[dag[len-1].sourceType].bitSize;
     const ubounded outputSize = type_dag[dag[len-1].targetType].bitSize;
     *cellsBound = bounded_add( bounded_add(inputSize, outputSize)
-                             , max(bound[len-1].extraCellsBound[0], bound[len-1].extraCellsBound[1])
+                             , bounded_max(bound[len-1].extraCellsBound[0], bound[len-1].extraCellsBound[1])
                              );
     *UWORDBound = (ubounded)ROUND_UWORD(inputSize) + (ubounded)ROUND_UWORD(outputSize)
-                + max(bound[len-1].extraUWORDBound[0], bound[len-1].extraUWORDBound[1]);
+                + bounded_max(bound[len-1].extraUWORDBound[0], bound[len-1].extraUWORDBound[1]);
     *frameBound = bound[len-1].extraFrameBound[0] + 2; /* add the initial input and output frames to the count. */
     *costBound = bound[len-1].cost;
   }

--- a/C/secp256k1/int128_struct_impl.h
+++ b/C/secp256k1/int128_struct_impl.h
@@ -25,7 +25,7 @@ static SECP256K1_INLINE int64_t secp256k1_mul128(int64_t a, int64_t b, int64_t* 
 /* On x84_64 MSVC, use native _(u)mul128 for 64x64->128 multiplications. */
 #        define secp256k1_umul128 _umul128
 static SECP256K1_INLINE uint64_t secp256k1_mul128(int64_t a, int64_t b, int64_t* hi) {
-    return (uint64_t)_mul128(a, b, hi)
+    return (uint64_t)_mul128(a, b, hi);
 }
 #    endif
 #else

--- a/C/type.c
+++ b/C/type.c
@@ -41,7 +41,7 @@ void computeTypeAnalyses(type* type_dag, const size_t len) {
       type_dag[i].bitSize = 0;
       break;
      case SUM:
-      type_dag[i].bitSize = max(type_dag[type_dag[i].typeArg[0]].bitSize, type_dag[type_dag[i].typeArg[1]].bitSize);
+      type_dag[i].bitSize = bounded_max(type_dag[type_dag[i].typeArg[0]].bitSize, type_dag[type_dag[i].typeArg[1]].bitSize);
       bounded_inc(&type_dag[i].bitSize);
       break;
      case PRODUCT:


### PR DESCRIPTION
related to: #211 

Fixes compilation errors on Windows/MSVC 

`_Static_assert` is not an issue when compiled with the c11 std 