### PR TITLE
Profiler support

### DIFF
--- a/C/test.c
+++ b/C/test.c
@@ -216,16 +216,14 @@ static void test_program(char* name, const unsigned char* program, size_t progra
       failures++;
       printf("Unexpected failure of fillWitnessData.\n");
     } else {
-      {
+      if (expectedAMR) {
         analyses analysis[len];
         computeAnnotatedMerkleRoot(analysis, dag, type_dag, (size_t)len);
-        if (expectedAMR) {
-          if (0 == memcmp(expectedAMR, analysis[len-1].annotatedMerkleRoot.s, sizeof(uint32_t[8]))) {
-            successes++;
-          } else {
-            failures++;
-            printf("Unexpected AMR.\n");
-          }
+        if (0 == memcmp(expectedAMR, analysis[len-1].annotatedMerkleRoot.s, sizeof(uint32_t[8]))) {
+          successes++;
+        } else {
+          failures++;
+          printf("Unexpected AMR.\n");
         }
       }
       {

--- a/Simplicity.C.nix
+++ b/Simplicity.C.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, gcovr ? null, wideMultiply ? null, withCoverage ? false
+, withProfiler ? false, gperftools ? null, graphviz ? null, perl ? null, librsvg ? null
 , production ? false
 , gcov-executable ? if stdenv.cc.isGNU then "gcov -r" else
                     if stdenv.cc.isClang then "${stdenv.cc.cc.libllvm}/bin/llvm-cov gcov"
@@ -10,6 +11,7 @@ assert wideMultiply == null
     || wideMultiply == "int128"
     || wideMultiply == "int128_struct";
 assert withCoverage -> gcovr != null && gcov-executable != null;
+assert withProfiler -> gperftools != null && graphviz != null && perl != null && librsvg != null;
 stdenv.mkDerivation {
   name = "libSimplicity-0.0.0";
   src = lib.sourceFilesBySuffices ./C ["Makefile" ".c" ".h" ".inc"];
@@ -17,11 +19,21 @@ stdenv.mkDerivation {
   CPPFLAGS = lib.optional (builtins.isString wideMultiply) "-DUSE_FORCE_WIDEMUL_${lib.toUpper wideMultiply}=1";
   CFLAGS = lib.optional withCoverage "--coverage"
         ++ lib.optional production "-DPRODUCTION";
-  LDFLAGS = lib.optional withCoverage "--coverage";
+  LDFLAGS = lib.optional withCoverage "--coverage"
+         ++ lib.optional withProfiler "-lprofiler";
+
   inherit doCheck;
+  checkInputs = lib.optionals withProfiler [ gperftools ];
+  nativeCheckInputs = lib.optionals withProfiler [ graphviz ];
   postCheck = lib.optional withCoverage ''
     mkdir -p $out/shared/coverage
     ${gcovr}/bin/gcovr --gcov-executable "${gcov-executable}" --verbose --html --html-details -o $out/shared/coverage/coverage.html
+  '' ++ lib.optional withProfiler ''
+    mkdir -p $out/shared/profile
+    CPUPROFILE=./prof.out CPUPROFILE_FREQUENCY=1000 ./test
+    # Until https://github.com/NixOS/nixpkgs/pull/279623 is resolved, we need to explicitly invoke perl
+    ${perl}/bin/perl ${gperftools}/bin/pprof --svg ./test prof.out > $out/shared/profile/test.svg
+    ${librsvg}/bin/rsvg-convert -f pdf -o $out/shared/profile/test.pdf $out/shared/profile/test.svg
   '';
   meta = {
     license = lib.licenses.mit;

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 , secp256k1git ? null
 , wideMultiply ? null
 , withCoverage ? false
+, withProfiler ? false
 , doCheck ? true
 , env ? "stdenv"
 }:
@@ -32,7 +33,7 @@ let hp = nixpkgs.haskell.packages.${ghc};
   };
 
   c = nixpkgs.callPackage ./Simplicity.C.nix {
-    inherit doCheck production wideMultiply withCoverage;
+    inherit doCheck production wideMultiply withCoverage withProfiler;
     stdenv = nixpkgs.${env};
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,9 +5,11 @@
 , ghc ? "ghc94"
 , coqPackages ? "coqPackages_8_16"
 , env ? "stdenv"
+, withCoverage ? true
+, withProfiler ? true
 }:
 let
-  simplicity      = import ./. {inherit nixpkgs ghc coqPackages env;};
+  simplicity      = import ./. {inherit nixpkgs ghc coqPackages env withCoverage withProfiler;};
   optional        = nixpkgs.lib.optional;
   haskellDevTools = pkgs: with pkgs; [cabal-install hlint hasktags];
   haskellPkgs     = pkgs: simplicity.haskell.buildInputs ++ simplicity.haskell.propagatedBuildInputs ++ haskellDevTools pkgs;


### PR DESCRIPTION
Add basic profiling support to the nix definition.

@apoelstra you probably want to add this configuration to your CI system.  Feel free to test `withProfiler` together with `withCoverage`.  We do not need to CI every permutation here.

Also included in the PR is a ammendment to `test.c` that avoids running `computeAnnotatedMerkleRoot` when the result will not be used.  This lets us gather timing data that reflects production use.