### PR TITLE
Make separate jet lib

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -1,4 +1,6 @@
-OBJS := bitstream.o dag.o deserialize.o eval.o frame.o jets.o jets-secp256k1.o rsort.o sha256.o type.o typeInference.o primitive/elements/env.o primitive/elements/exec.o primitive/elements/ops.o primitive/elements/jets.o primitive/elements/primitive.o
+JET_OBJS := frame.o jets.o jets-secp256k1.o sha256.o primitive/elements/ops.o primitive/elements/jets.o
+OBJS := $(JET_OBJS) bitstream.o dag.o deserialize.o eval.o rsort.o type.o typeInference.o primitive/elements/env.o primitive/elements/exec.o primitive/elements/primitive.o
+WRAPPED_JET_OBJS := $(JET_OBJS) wrappedJets/coreJets.c wrappedJets/elements/jets.c
 TEST_OBJS := test.o ctx8Pruned.o ctx8Unpruned.o hashBlock.o schnorr0.o schnorr6.o primitive/elements/checkSigHashAllTx1.o
 
 # From https://fastcompression.blogspot.com/2019/01/compiler-warnings.html
@@ -23,10 +25,13 @@ primitive/elements/jets.o: primitive/elements/jets.c
 libElementsSimplicity.a: $(OBJS)
 	ar rcs $@ $^
 
+libElementsJets.a: $(WRAPPED_JET_OBJS)
+	ar rcs $@ $^
+
 test: $(TEST_OBJS) libElementsSimplicity.a
 	$(CC) $^ -o $@ $(LDFLAGS)
 
-install: libElementsSimplicity.a
+install: libElementsJets.a libElementsSimplicity.a
 	mkdir -p $(out)/lib
 	cp $^ $(out)/lib/
 	cp -R include $(out)/include
@@ -35,6 +40,6 @@ check: test
 	./test
 
 clean:
-	-rm -f test libElementsSimplicity.a $(TEST_OBJS) $(OBJS)
+	-rm -f test libElementsJets.a libElementsSimplicity.a $(TEST_OBJS) $(OBJS)
 
 .PHONY: install check clean

--- a/C/wrappedJets/coreJets.c
+++ b/C/wrappedJets/coreJets.c
@@ -1,4 +1,4 @@
-#include "jets.h"
+#include "../jets.h"
 #include "wrappers.h"
 
 COREWRAP_(verify)

--- a/C/wrappedJets/elements/jets.c
+++ b/C/wrappedJets/elements/jets.c
@@ -1,4 +1,4 @@
-#include "primitive/elements/jets.h"
+#include "../../primitive/elements/jets.h"
 #include "../wrappers.h"
 
 WRAP_(version)

--- a/C/wrappedJets/wrappers.h
+++ b/C/wrappedJets/wrappers.h
@@ -3,17 +3,33 @@
 
 #include "simplicity_assert.h"
 
+/* In test suites, like the Haskell testsuite, we use test jets via these wrappers.
+ * During that testing we allocate a correctly sized frame for each jet,
+ * and as part of the testing we want to verify that jet writes to the end of that specifically allocated frame.
+ *
+ * However, other uses of these jets may call jets in which jets will only write to part of the frame.
+ * (this would happen, for instance, when executing jets in a bit machine context.)
+ *
+ * Therefore we only enable these assertions when JET_FRAME_TESTING is enabled.
+ */
+#ifdef JET_FRAME_TESTING
+#  define JET_FRAME_TESTING_FLAG 1
+#else
+#  define JET_FRAME_TESTING_FLAG 0
+#endif
+#define simplicity_jet_frame_assert(cond) do { if (JET_FRAME_TESTING_FLAG) { simplicity_assert(cond); } } while(0)
+
 #define COREWRAP_(jet)                                                                                                        \
 bool c_##jet(frameItem* dst, const frameItem* src) {                                                                          \
   bool result = jet(dst, *src, NULL);                                                                                         \
-  simplicity_debug_assert (!result || 0 == dst->offset);                                                                                       \
+  simplicity_jet_frame_assert(!result || 0 == dst->offset);                                                                   \
   return result;                                                                                                              \
 }
 
 #define WRAP_(jet)                                                                                                            \
 bool c_##jet(frameItem* dst, const frameItem* src, const txEnv* env) {                                                        \
   bool result = jet(dst, *src, env);                                                                                          \
-  simplicity_debug_assert (!result || 0 == dst->offset);                                                                                       \
+  simplicity_jet_frame_assert(!result || 0 == dst->offset);                                                                   \
   return result;                                                                                                              \
 }
 

--- a/C/wrappedJets/wrappers.h
+++ b/C/wrappedJets/wrappers.h
@@ -1,17 +1,19 @@
 #ifndef WRAPPEDJETS_WRAPPERS_H
 #define WRAPPEDJETS_WRAPPERS_H
 
+#include "simplicity_assert.h"
+
 #define COREWRAP_(jet)                                                                                                        \
 bool c_##jet(frameItem* dst, const frameItem* src) {                                                                          \
   bool result = jet(dst, *src, NULL);                                                                                         \
-  assert (!result || 0 == dst->offset);                                                                                       \
+  simplicity_debug_assert (!result || 0 == dst->offset);                                                                                       \
   return result;                                                                                                              \
 }
 
 #define WRAP_(jet)                                                                                                            \
 bool c_##jet(frameItem* dst, const frameItem* src, const txEnv* env) {                                                        \
   bool result = jet(dst, *src, env);                                                                                          \
-  assert (!result || 0 == dst->offset);                                                                                       \
+  simplicity_debug_assert (!result || 0 == dst->offset);                                                                                       \
   return result;                                                                                                              \
 }
 

--- a/C/wrappedJets/wrappers.h
+++ b/C/wrappedJets/wrappers.h
@@ -1,5 +1,5 @@
-#ifndef WRAPPERS_H
-#define WRAPPERS_H
+#ifndef WRAPPEDJETS_WRAPPERS_H
+#define WRAPPEDJETS_WRAPPERS_H
 
 #define COREWRAP_(jet)                                                                                                        \
 bool c_##jet(frameItem* dst, const frameItem* src) {                                                                          \

--- a/C/wrappedJets/wrappers.h
+++ b/C/wrappedJets/wrappers.h
@@ -1,7 +1,7 @@
 #ifndef WRAPPEDJETS_WRAPPERS_H
 #define WRAPPEDJETS_WRAPPERS_H
 
-#include "simplicity_assert.h"
+#include "../simplicity_assert.h"
 
 /* In test suites, like the Haskell testsuite, we use test jets via these wrappers.
  * During that testing we allocate a correctly sized frame for each jet,

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -18,6 +18,7 @@ library Simplicity-Core
                        Haskell/cbits/frame.c
   Include-dirs:        C
   Includes:            sha256.h, frame.h, jets.h
+  cc-options:         -DJET_FRAME_TESTING
   exposed-modules:     Simplicity.Ty, Simplicity.Ty.Bit, Simplicity.Ty.Word,
                        Simplicity.Term.Core,
                        Simplicity.CoreJets,
@@ -127,6 +128,7 @@ library
                        C/wrappedJets/elements/jets.c Haskell/cbits/elements/env.c
   Include-dirs:        C C/include
   Includes:            primitive/elements/jets.h primitive/elements/primitive.h simplicity/elements/env.h
+  cc-options:         -DJET_FRAME_TESTING
   exposed-modules:     Simplicity.Bitcoin.Programs.Transaction, Simplicity.Bitcoin.Programs.Transaction.Lib,
                        Simplicity.Bitcoin.Programs.TimeLock, Simplicity.Elements.Programs.TimeLock,
                        Simplicity.Elements.Programs.Issuance, Simplicity.Elements.Programs.Issuance.Lib,

--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -14,8 +14,8 @@ extra-source-files:  README.md
 tested-with:         GHC ==8.6.4
 
 library Simplicity-Core
-  C-sources:           C/sha256.c, C/frame.c, C/jets.c, C/jets-secp256k1.c
-                       Haskell/cbits/frame.c, Haskell/cbits/coreJets.c
+  C-sources:           C/sha256.c, C/frame.c, C/jets.c, C/jets-secp256k1.c, C/wrappedJets/coreJets.c
+                       Haskell/cbits/frame.c
   Include-dirs:        C
   Includes:            sha256.h, frame.h, jets.h
   exposed-modules:     Simplicity.Ty, Simplicity.Ty.Bit, Simplicity.Ty.Word,
@@ -124,7 +124,7 @@ library Simplicity-Indef
 
 library
   C-sources:           C/primitive/elements/jets.c C/primitive/elements/ops.c C/primitive/elements/env.c
-                       Haskell/cbits/elements/jets.c Haskell/cbits/elements/env.c
+                       C/wrappedJets/elements/jets.c Haskell/cbits/elements/env.c
   Include-dirs:        C C/include
   Includes:            primitive/elements/jets.h primitive/elements/primitive.h simplicity/elements/env.h
   exposed-modules:     Simplicity.Bitcoin.Programs.Transaction, Simplicity.Bitcoin.Programs.Transaction.Lib,


### PR DESCRIPTION
Only a subset of files is required for jet execution. Our goal is to port this subset for WASM.

rust-simplicity-sys doesn't call the local Makefile, but a target for jets will make it easier to track WASM compatibility.

# Current progress

I identified a closed subset of files that includes all jet implementations.

[rust-simplicity-sys](https://github.com/uncomputable/rust-simplicity/tree/only-jets) uses the same set of files and successfully runs on x86_64 and WASM.

# Limitations

There are no unit tests because the parsing of programs etc. is not included.

Elements transaction environments cannot be built because allocations were removed.