### PR TITLE
Valgrind

### DIFF
--- a/Simplicity.C.nix
+++ b/Simplicity.C.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, gcovr ? null, wideMultiply ? null, withCoverage ? false
 , withProfiler ? false, gperftools ? null, graphviz ? null, perl ? null, librsvg ? null
+, withTiming ? true
 , production ? false
 , gcov-executable ? if stdenv.cc.isGNU then "gcov -r" else
                     if stdenv.cc.isClang then "${stdenv.cc.cc.libllvm}/bin/llvm-cov gcov"
@@ -18,6 +19,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   CPPFLAGS = lib.optional (builtins.isString wideMultiply) "-DUSE_FORCE_WIDEMUL_${lib.toUpper wideMultiply}=1";
   CFLAGS = lib.optional withCoverage "--coverage"
+        ++ lib.optional withTiming "-DTIMING_FLAG"
         ++ lib.optional production "-DPRODUCTION";
   LDFLAGS = lib.optional withCoverage "--coverage"
          ++ lib.optional withProfiler "-lprofiler";

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
 , wideMultiply ? null
 , withCoverage ? false
 , withProfiler ? false
+, withTiming ? true
 , doCheck ? true
 , env ? "stdenv"
 }:
@@ -33,7 +34,7 @@ let hp = nixpkgs.haskell.packages.${ghc};
   };
 
   c = nixpkgs.callPackage ./Simplicity.C.nix {
-    inherit doCheck production wideMultiply withCoverage withProfiler;
+    inherit doCheck production wideMultiply withCoverage withProfiler withTiming;
     stdenv = nixpkgs.${env};
   };
 

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
 , withCoverage ? false
 , withProfiler ? false
 , withTiming ? true
+, withValgrind ? false
 , doCheck ? true
 , env ? "stdenv"
 }:
@@ -34,7 +35,7 @@ let hp = nixpkgs.haskell.packages.${ghc};
   };
 
   c = nixpkgs.callPackage ./Simplicity.C.nix {
-    inherit doCheck production wideMultiply withCoverage withProfiler withTiming;
+    inherit doCheck production wideMultiply withCoverage withProfiler withTiming withValgrind;
     stdenv = nixpkgs.${env};
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,9 +7,10 @@
 , env ? "stdenv"
 , withCoverage ? true
 , withProfiler ? true
+, withValgrind ? true
 }:
 let
-  simplicity      = import ./. {inherit nixpkgs ghc coqPackages env withCoverage withProfiler;};
+  simplicity      = import ./. {inherit nixpkgs ghc coqPackages env withCoverage withProfiler withValgrind;};
   optional        = nixpkgs.lib.optional;
   haskellDevTools = pkgs: with pkgs; [cabal-install hlint hasktags];
   haskellPkgs     = pkgs: simplicity.haskell.buildInputs ++ simplicity.haskell.propagatedBuildInputs ++ haskellDevTools pkgs;


### PR DESCRIPTION
This PR adds two features.

One is an option to ignore the results of the timing tests.  It can be disabled in nix builds by setting the `withTiming` argument to `false`.

The second feature is an option to run `valgrind` on the test suite in the `CheckPhase`.  This can be enabled in nix builds by setting the `withValgrind` argument to `true`.