### PR TITLE
Generate Rust for WASM

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -363,9 +363,8 @@ rustJetDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
 
 rustFFIImports :: Doc a
 rustFFIImports = vsep (map (<> semi)
-  [ "use std::ffi::c_void"
-  , "use super::c_env::CElementsTxEnv"
-  , "use super::frame_ffi::CFrameItem"
+  [ "use crate::ffi::c_void"
+  , "use crate::{CElementsTxEnv, CFrameItem}"
   ])
 
 rustFFISigs :: Module -> Doc a
@@ -395,8 +394,8 @@ rustFFIDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
 
 rustWrapperImports :: Doc a
 rustWrapperImports = vsep (map (<> semi)
-  [ "use crate::CElementsTxEnv"
-  , "use super::{frame_ffi::CFrameItem, elements_ffi}"
+  [ "use crate::{CElementsTxEnv, CFrameItem}"
+  , "use super::elements_ffi"
   ])
 
 rustWrappers :: Module -> Doc a

--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -417,21 +417,12 @@ rustWrapperDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
   , rustWrappers mod
   ])
 
-rustCoreJetDoc :: SimpleDocStream a
-rustCoreJetDoc = rustJetDoc coreModule
-
-rustElementsJetDoc :: SimpleDocStream a
-rustElementsJetDoc = rustJetDoc elementsModule
-
-rustBitcoinJetDoc :: SimpleDocStream a
-rustBitcoinJetDoc = rustJetDoc bitcoinModule
-
 renderFile name doc = withFile name WriteMode (\h -> renderIO h doc)
 
 main = do
-  renderFile "core.rs" rustCoreJetDoc
-  renderFile "elements.rs" rustElementsJetDoc
-  renderFile "bitcoin.rs" rustBitcoinJetDoc
+  renderFile "core.rs" (rustJetDoc coreModule)
+  renderFile "elements.rs" (rustJetDoc elementsModule)
+  renderFile "bitcoin.rs" (rustJetDoc bitcoinModule)
   renderFile "jets_ffi.rs" (rustFFIDoc elementsModule)
   renderFile "jets_wrapper.rs" (rustWrapperDoc elementsModule)
 

--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -424,6 +424,25 @@ rustWrapperDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
   , rustWrappers mod
   ])
 
+cWrapperImports :: Doc a
+cWrapperImports = vsep
+  [ "#include \"simplicity/primitive/elements/jets.h\""
+  , "#include \"simplicity/simplicity_assert.h\""
+  , "#include \"wrapper.h\""
+  ]
+
+cWrappers :: Module -> Doc a
+cWrappers mod = vsep (map wrapper $ moduleJets mod)
+ where
+  wrapper (SomeArrow jet) = pretty $ "WRAP_("++cJetName jet++")"
+
+cWrapperDoc :: Module -> SimpleDocStream a
+cWrapperDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
+  [ rustHeader -- also works for C
+  , cWrapperImports
+  , cWrappers mod
+  ])
+
 renderFile name doc = withFile name WriteMode (\h -> renderIO h doc)
 
 main = do
@@ -432,5 +451,6 @@ main = do
   renderFile "bitcoin.rs" (rustJetDoc bitcoinModule)
   renderFile "jets_ffi.rs" (rustFFIDoc elementsModule)
   renderFile "jets_wrapper.rs" (rustWrapperDoc elementsModule)
+  renderFile "jets_wrapper.c" (cWrapperDoc elementsModule)
 
 layoutOptions = LayoutOptions { layoutPageWidth = AvailablePerLine 100 1 }


### PR DESCRIPTION
Update the Rust code generator to bind wrapped jet functions (which take source frames by reference). Raw jet functions (which take source frames by value) are invisible to the Rust code, which is needed for WASM. Add a generator of wrapped jet functions.