### PR TITLE
Simplicity alloc

### DIFF
--- a/C/bitstream.c
+++ b/C/bitstream.c
@@ -1,7 +1,6 @@
 #include "bitstream.h"
 
 #include <limits.h>
-#include <stdlib.h>
 #include "simplicity_assert.h"
 
 /* Closes a bitstream by consuming all remaining bits.

--- a/C/dag.c
+++ b/C/dag.c
@@ -6,6 +6,7 @@
 #include "prefix.h"
 #include "rsort.h"
 #include "sha256.h"
+#include "simplicity_alloc.h"
 #include "uword.h"
 
 /* Given a tag for a node, return the SHA-256 hash of its associated CMR tag.
@@ -573,7 +574,7 @@ simplicity_err fillWitnessData(dag_node* dag, type* type_dag, const size_t len, 
  */
 simplicity_err verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const size_t dag_len) {
   simplicity_assert(0 < dag_len);
-  sha256_midstate* imr_buf = malloc((size_t)dag_len * sizeof(sha256_midstate));
+  sha256_midstate* imr_buf = simplicity_malloc((size_t)dag_len * sizeof(sha256_midstate));
   if (!imr_buf) return SIMPLICITY_ERR_MALLOC;
 
   computeIdentityMerkleRoot(imr_buf, dag, type_dag, dag_len);
@@ -582,7 +583,7 @@ simplicity_err verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_no
 
   int result = hasDuplicates(imr_buf, dag_len);
 
-  free(imr_buf);
+  simplicity_free(imr_buf);
 
   switch (result) {
   case -1: return SIMPLICITY_ERR_MALLOC;

--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -1,9 +1,9 @@
 #include "deserialize.h"
 
 #include <limits.h>
-#include <stdlib.h>
 #include "limitations.h"
 #include "primitive.h"
+#include "simplicity_alloc.h"
 #include "simplicity_assert.h"
 
 /* Fetches 'len' 'uint32_t's from 'stream' into 'result'.
@@ -195,7 +195,7 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(dag_node), "dag array too large.");
   static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
   static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "dag array index does not fit in uint32_t.");
-  *dag = malloc((size_t)dagLen * sizeof(dag_node));
+  *dag = simplicity_malloc((size_t)dagLen * sizeof(dag_node));
   if (!*dag) return SIMPLICITY_ERR_MALLOC;
 
   if (census) *census = (combinator_counters){0};
@@ -210,7 +210,7 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   if (IS_OK(error)) {
     return dagLen;
   } else {
-    free(*dag);
+    simplicity_free(*dag);
     *dag = NULL;
     return (int32_t)error;
   }

--- a/C/eval.c
+++ b/C/eval.c
@@ -1,9 +1,9 @@
 #include "eval.h"
 
 #include <string.h>
-#include <stdlib.h>
 #include "bounded.h"
 #include "limitations.h"
+#include "simplicity_alloc.h"
 #include "simplicity_assert.h"
 
 /* We choose an unusual representation for frames of the Bit Machine.
@@ -589,7 +589,7 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
   static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "bound array index does not fit in uint32_t.");
   simplicity_assert(1 <= len);
   simplicity_assert(len <= DAG_LEN_MAX);
-  boundsAnalysis* bound = malloc(len * sizeof(boundsAnalysis));
+  boundsAnalysis* bound = simplicity_malloc(len * sizeof(boundsAnalysis));
   if (!bound) return SIMPLICITY_ERR_MALLOC;
 
   /* Sum up the total costs.
@@ -744,7 +744,7 @@ simplicity_err analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubound
     *frameBound = bound[len-1].extraFrameBound[0] + 2; /* add the initial input and output frames to the count. */
     *costBound = bound[len-1].cost;
   }
-  free(bound);
+  simplicity_free(bound);
   /* Note that the cellsBound and costBound computations have been clipped at UBOUNDED_MAX.
    * Therefore setting maxCells or maxCost to UBOUNDED_MAX will disable the corresponding error check.
    */
@@ -802,12 +802,12 @@ simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, con
 
   /* We use calloc for 'cells' because the frame data must be initialized before we can perform bitwise operations. */
   static_assert(CELLS_MAX - 1 <= UINT32_MAX, "cells array index does not fit in uint32_t.");
-  UWORD* cells = calloc(UWORDBound ? UWORDBound : 1, sizeof(UWORD));
+  UWORD* cells = simplicity_calloc(UWORDBound ? UWORDBound : 1, sizeof(UWORD));
   static_assert(2*DAG_LEN_MAX <= SIZE_MAX / sizeof(frameItem), "frames array does not fit in size_t.");
   static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
   static_assert(2*DAG_LEN_MAX - 1 <= UINT32_MAX, "frames array index does not fit in uint32_t.");
-  frameItem* frames = malloc(frameBound * sizeof(frameItem));
-  call* stack = calloc(len, sizeof(call));
+  frameItem* frames = simplicity_malloc(frameBound * sizeof(frameItem));
+  call* stack = simplicity_calloc(len, sizeof(call));
 
   result = cells && frames && stack ? SIMPLICITY_NO_ERROR : SIMPLICITY_ERR_MALLOC;
   if (IS_OK(result)) {
@@ -833,8 +833,8 @@ simplicity_err evalTCOExpression( flags_type anti_dos_checks, UWORD* output, con
     }
   }
 
-  free(stack);
-  free(frames);
-  free(cells);
+  simplicity_free(stack);
+  simplicity_free(frames);
+  simplicity_free(cells);
   return result;
 }

--- a/C/primitive/elements/env.c
+++ b/C/primitive/elements/env.c
@@ -2,13 +2,13 @@
 
 #include <stdalign.h>
 #include <stddef.h>
-#include <stdlib.h>
 #include <string.h>
 #include "primitive.h"
 #include "ops.h"
 #include "../../rsort.h"
 #include "../../sha256.h"
 #include "../../simplicity_assert.h"
+#include "../../simplicity_alloc.h"
 
 #define PADDING(alignType, allocated) ((alignof(alignType) - (allocated) % alignof(alignType)) % alignof(alignType))
 
@@ -410,7 +410,7 @@ extern transaction* elements_simplicity_mallocTransaction(const rawTransaction* 
   if (SIZE_MAX - allocationSize < totalNullDataCodes * sizeof(opcode)) return NULL;
   allocationSize += totalNullDataCodes * sizeof(opcode);
 
-  char *allocation = malloc(allocationSize);
+  char *allocation = simplicity_malloc(allocationSize);
   if (!allocation) return NULL;
 
   /* Casting through void* to avoid warning about pointer alignment.
@@ -576,7 +576,7 @@ extern transaction* elements_simplicity_mallocTransaction(const rawTransaction* 
 
     simplicity_assert(numFees == ix_fee);
     if (!rsort(perm, numFees)) {
-      free(tx);
+      simplicity_free(tx);
       return NULL;
     }
 
@@ -647,7 +647,7 @@ extern tapEnv* elements_simplicity_mallocTapEnv(const rawTapEnv* rawEnv) {
     allocationSize += numMidstate * sizeof(sha256_midstate);
   }
 
-  char *allocation = malloc(allocationSize);
+  char *allocation = simplicity_malloc(allocationSize);
   if (!allocation) return NULL;
 
   /* Casting through void* to avoid warning about pointer alignment.

--- a/C/primitive/elements/exec.c
+++ b/C/primitive/elements/exec.c
@@ -1,12 +1,12 @@
 #include <simplicity/elements/exec.h>
 
-#include <stdlib.h>
 #include <stdalign.h>
 #include <string.h>
 #include "primitive.h"
 #include "../../deserialize.h"
 #include "../../eval.h"
 #include "../../limitations.h"
+#include "../../simplicity_alloc.h"
 #include "../../simplicity_assert.h"
 #include "../../typeInference.h"
 
@@ -98,7 +98,7 @@ extern bool elements_simplicity_execSimplicity( simplicity_err* error, unsigned 
       static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(analyses), "analysis array too large.");
       static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
       static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "analysis array index does nto fit in uint32_t.");
-      analyses *analysis = malloc((size_t)dag_len * sizeof(analyses));
+      analyses *analysis = simplicity_malloc((size_t)dag_len * sizeof(analyses));
       if (analysis) {
         computeAnnotatedMerkleRoot(analysis, dag, type_dag, (size_t)dag_len);
         if (0 != memcmp(amr_hash.s, analysis[dag_len-1].annotatedMerkleRoot.s, sizeof(uint32_t[8]))) {
@@ -108,16 +108,16 @@ extern bool elements_simplicity_execSimplicity( simplicity_err* error, unsigned 
         /* malloc failed which counts as a transient error. */
         *error = SIMPLICITY_ERR_MALLOC;
       }
-      free(analysis);
+      simplicity_free(analysis);
     }
     if (IS_OK(*error)) {
       txEnv env = build_txEnv(tx, taproot, &genesis_hash, ix);
       static_assert(BUDGET_MAX <= UBOUNDED_MAX, "BUDGET_MAX doesn't fit in ubounded.");
       *error = evalTCOProgram(dag, type_dag, (size_t)dag_len, &(ubounded){budget <= BUDGET_MAX ? (ubounded)budget : BUDGET_MAX}, &env);
     }
-    free(type_dag);
+    simplicity_free(type_dag);
   }
 
-  free(dag);
+  simplicity_free(dag);
   return IS_PERMANENT(*error);
 }

--- a/C/primitive/elements/primitive.c
+++ b/C/primitive/elements/primitive.c
@@ -2,11 +2,11 @@
  */
 #include "primitive.h"
 
-#include <stdlib.h>
 #include "jets.h"
 #include "../../limitations.h"
 #include "../../prefix.h"
 #include "../../primitive.h"
+#include "../../simplicity_alloc.h"
 #include "../../simplicity_assert.h"
 
 /* An enumeration of all the types we need to construct to specify the input and output types of all jets created by 'decodeJet'. */
@@ -40,7 +40,7 @@ size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix, size_t* 
   static_assert(NumberOfTypeNames + 6*DAG_LEN_MAX <= SIZE_MAX/sizeof(unification_var) , "bound_var array too large");
   static_assert(NumberOfTypeNames + 6*DAG_LEN_MAX - 1 <= UINT32_MAX, "bound_var array index doesn't fit in uint32_t");
   simplicity_assert(extra_var_len <= 6*DAG_LEN_MAX);
-  *bound_var = malloc((NumberOfTypeNames + extra_var_len) * sizeof(unification_var));
+  *bound_var = simplicity_malloc((NumberOfTypeNames + extra_var_len) * sizeof(unification_var));
   if (!(*bound_var)) return 0;
 #include "primitiveInitTy.inc"
   *word256_ix = ty_w256;

--- a/C/rsort.c
+++ b/C/rsort.c
@@ -1,7 +1,9 @@
 #include "rsort.h"
 
 #include <string.h>
+
 #include "simplicity_assert.h"
+#include "simplicity_alloc.h"
 
 static_assert(UCHAR_MAX < SIZE_MAX, "UCHAR_MAX >= SIZE_MAX");
 #define CHAR_COUNT ((size_t)1 << CHAR_BIT)
@@ -245,10 +247,10 @@ static void rsort_ex(const sha256_midstate** a, uint_fast32_t len, const sha256_
  * Precondition: For all 0 <= i < len, NULL != a[i];
  */
 bool rsort(const sha256_midstate** a, uint_fast32_t len) {
-  uint32_t *stack = malloc(((CHAR_COUNT - 1)*(sizeof((*a)->s)) + 1) * sizeof(uint32_t));
+  uint32_t *stack = simplicity_malloc(((CHAR_COUNT - 1)*(sizeof((*a)->s)) + 1) * sizeof(uint32_t));
   if (!stack) return false;
   rsort_ex(a, len, NULL, stack);
-  free(stack);
+  simplicity_free(stack);
   return true;
 }
 
@@ -266,8 +268,8 @@ int hasDuplicates(const sha256_midstate* a, uint_fast32_t len) {
   static_assert(DAG_LEN_MAX <= UINT32_MAX, "DAG_LEN_MAX does not fit in uint32_t.");
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(const sha256_midstate*), "perm array too large.");
   simplicity_assert(len <= SIZE_MAX / sizeof(const sha256_midstate*));
-  const sha256_midstate **perm = malloc(len * sizeof(const sha256_midstate*));
-  uint32_t *stack = malloc(((CHAR_COUNT - 1)*(sizeof((*perm)->s)) + 1) * sizeof(uint32_t));
+  const sha256_midstate **perm = simplicity_malloc(len * sizeof(const sha256_midstate*));
+  uint32_t *stack = simplicity_malloc(((CHAR_COUNT - 1)*(sizeof((*perm)->s)) + 1) * sizeof(uint32_t));
   int result = perm && stack ? 0 : -1;
 
   if (0 <= result) {
@@ -280,7 +282,7 @@ int hasDuplicates(const sha256_midstate* a, uint_fast32_t len) {
     result = NULL != duplicate;
   }
 
-  free(perm);
-  free(stack);
+  simplicity_free(perm);
+  simplicity_free(stack);
   return result;
 }

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -4,7 +4,6 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #include "limitations.h"
 #include "sha256.h"

--- a/C/simplicity_alloc.h
+++ b/C/simplicity_alloc.h
@@ -1,0 +1,15 @@
+#ifndef SIMPLICITY_SIMPLICITY_ALLOC_H
+#define SIMPLICITY_SIMPLICITY_ALLOC_H
+
+#include <stdlib.h>
+
+/* Allocate with malloc by default. */
+#define simplicity_malloc malloc
+
+/* Allocate+zero initialize with calloc by default. */
+#define simplicity_calloc calloc
+
+/* Deallocate with free by default. */
+#define simplicity_free free
+
+#endif /* SIMPLICITY_SIMPLICITY_ALLOC_H */

--- a/C/test.c
+++ b/C/test.c
@@ -14,6 +14,7 @@
 #include "sha256.h"
 #include "schnorr0.h"
 #include "schnorr6.h"
+#include "simplicity_alloc.h"
 #include "typeInference.h"
 #include "primitive/elements/checkSigHashAllTx1.h"
 
@@ -164,9 +165,9 @@ static void test_hashBlock(void) {
         printf("Unexpected failure of hashblock evaluation: %d\n", err);
       }
     }
-    free(type_dag);
+    simplicity_free(type_dag);
   }
-  free(dag);
+  simplicity_free(dag);
 }
 
 static void test_program(char* name, const unsigned char* program, size_t program_len, simplicity_err expectedResult, const uint32_t* expectedCMR,
@@ -286,9 +287,9 @@ static void test_program(char* name, const unsigned char* program, size_t progra
         printf("Expected %d from evaluation, but got %d instead.\n", expectedResult, actualResult);
       }
     }
-    free(type_dag);
+    simplicity_free(type_dag);
   }
-  free(dag);
+  simplicity_free(dag);
 }
 
 static void test_occursCheck(void) {
@@ -313,9 +314,9 @@ static void test_occursCheck(void) {
       printf("Unexpected occurs check success\n");
       failures++;
     }
-    free(type_dag);
+    simplicity_free(type_dag);
   }
-  free(dag);
+  simplicity_free(dag);
 }
 
 static void test_elements(void) {
@@ -409,7 +410,7 @@ static void test_elements(void) {
       printf("mallocTransaction(&rawTx1) failed\n");
       failures++;
     }
-    free(tx1);
+    simplicity_free(tx1);
   }
   /* test a modified transaction with the same signature. */
   {
@@ -457,9 +458,9 @@ static void test_elements(void) {
       printf("mallocTransaction(&testTx2) failed\n");
       failures++;
     }
-    free(tx2);
+    simplicity_free(tx2);
   }
-  free(taproot);
+  simplicity_free(taproot);
 }
 
 static sha256_midstate hashint(uint_fast32_t n) {
@@ -531,7 +532,7 @@ static void regression_tests(void) {
   {
     /* word("2^23 zero bits") ; unit */
     size_t sizeof_regression3 = ((size_t)1 << 20) + 4;
-    unsigned char *regression3 = calloc(sizeof_regression3, 1);
+    unsigned char *regression3 = simplicity_calloc(sizeof_regression3, 1);
     clock_t start, end;
     double diff, bound;
     const uint32_t cmr[] = {
@@ -554,7 +555,7 @@ static void regression_tests(void) {
         printf("regression3 took too long.\n");
       }
     }
-    free(regression3);
+    simplicity_free(regression3);
   }
 }
 

--- a/Haskell/cbits/elements/env.c
+++ b/Haskell/cbits/elements/env.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include "simplicity_alloc.h"
 #include "simplicity/elements/env.h"
 #include "primitive/elements/primitive.h"
 
@@ -68,9 +68,9 @@ void c_set_txEnv(txEnv* result, const transaction* tx, const tapEnv* taproot, co
 }
 
 void c_free_tapEnv(tapEnv* env) {
-  free(env);
+  simplicity_free(env);
 }
 
 void c_free_transaction(transaction* tx) {
-  free(tx);
+  simplicity_free(tx);
 }


### PR DESCRIPTION
Simplicity (de)allocation macros in the style of `simplicity_assert.h`. These macros can be overwritten to use Rust functions that are injected into C via FFI.

Environment allocation functions that return the number of allocated bytes.