### PR TITLE
GenRust: Update c_jet_env

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -268,7 +268,7 @@ rustJetImpl mod = vsep $
     [ pretty $ "type Environment = "++env++";"
     , pretty $ "type CJetEnvironment = "++cEnv++";"
     , ""
-    , pretty $ "fn c_jet_env<'env>(&self, "++envArg++": &'env Self::Environment) -> &'env Self::CJetEnvironment {"
+    , pretty $ "fn c_jet_env("++envArg++": &Self::Environment) -> &Self::CJetEnvironment {"
     , pretty $ "    "++envBody
     , "}"
     ]


### PR DESCRIPTION
This function converts a Rust environment into a C environment. The specific jet is not used at all and can be dropped from the function signature.