### PR TITLE
Update invariant of rawTapEnv

### DIFF
--- a/C/include/simplicity/elements/env.h
+++ b/C/include/simplicity/elements/env.h
@@ -97,6 +97,7 @@ extern transaction* elements_simplicity_mallocTransaction(const rawTransaction* 
  *
  * Invariant: pathLen <= 128;
  *            unsigned char controlBlock[33+pathLen*32];
+ *            unsigned char scriptCMR[32];
  */
 typedef struct rawTapEnv {
   const unsigned char* controlBlock;


### PR DESCRIPTION
We need to explicitly state that scriptCMR must be 32 bytes.

This feedback came from @delta1.