### PR TITLE
Add API to compute CMRs

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -1,4 +1,4 @@
-OBJS := bitstream.o dag.o deserialize.o eval.o frame.o jets.o jets-secp256k1.o rsort.o sha256.o type.o typeInference.o primitive/elements/env.o primitive/elements/exec.o primitive/elements/ops.o primitive/elements/jets.o primitive/elements/primitive.o
+OBJS := bitstream.o cmr.o dag.o deserialize.o eval.o frame.o jets.o jets-secp256k1.o rsort.o sha256.o type.o typeInference.o primitive/elements/env.o primitive/elements/exec.o primitive/elements/ops.o primitive/elements/jets.o primitive/elements/primitive.o
 TEST_OBJS := test.o ctx8Pruned.o ctx8Unpruned.o hashBlock.o schnorr0.o schnorr6.o primitive/elements/checkSigHashAllTx1.o
 
 # From https://fastcompression.blogspot.com/2019/01/compiler-warnings.html

--- a/C/cmr.c
+++ b/C/cmr.c
@@ -1,0 +1,42 @@
+#include <simplicity/cmr.h>
+
+#include "deserialize.h"
+#include "limitations.h"
+#include "simplicity_alloc.h"
+#include "simplicity_assert.h"
+
+/* Deserialize a Simplicity 'program' and compute its CMR.
+ *
+ * Caution: no typechecking is performed, only a well-formedness check.
+ *
+ * If at any time malloc fails then '*error' is set to 'SIMPLICITY_ERR_MALLOC' and 'false' is returned,
+ * Otherwise, 'true' is returned indicating that the result was successfully computed and returned in the '*error' value.
+ *
+ * If the operation completes successfully then '*error' is set to 'SIMPLICITY_NO_ERROR', and the 'cmr' array is filled in with the program's computed CMR.
+ *
+ * Precondition: NULL != error;
+ *               unsigned char cmr[32]
+ *               unsigned char program[program_len]
+ */
+bool simplicity_computeCmr( simplicity_err* error, unsigned char* cmr
+                          , const unsigned char* program, size_t program_len) {
+  simplicity_assert(NULL != error);
+  simplicity_assert(NULL != cmr);
+  simplicity_assert(NULL != program || 0 == program_len);
+
+  bitstream stream = initializeBitstream(program, program_len);
+  dag_node* dag = NULL;
+  int32_t dag_len = decodeMallocDag(&dag, NULL, &stream);
+  if (dag_len <= 0) {
+    simplicity_assert(dag_len < 0);
+    *error = dag_len;
+  } else {
+    simplicity_assert(NULL != dag);
+    simplicity_assert((size_t)dag_len <= DAG_LEN_MAX);
+    *error = SIMPLICITY_NO_ERROR;
+    sha256_fromMidstate(cmr, dag[dag_len-1].cmr.s);
+  }
+
+  simplicity_free(dag);
+  return IS_PERMANENT(*error);
+}

--- a/C/include/simplicity/cmr.h
+++ b/C/include/simplicity/cmr.h
@@ -1,0 +1,23 @@
+#ifndef SIMPLICITY_CMR_H
+#define SIMPLICITY_CMR_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <simplicity/errorCodes.h>
+
+/* Deserialize a Simplicity 'program' and compute its CMR.
+ *
+ * Caution: no typechecking is performed, only a well-formedness check.
+ *
+ * If at any time malloc fails then '*error' is set to 'SIMPLICITY_ERR_MALLOC' and 'false' is returned,
+ * Otherwise, 'true' is returned indicating that the result was successfully computed and returned in the '*error' value.
+ *
+ * If the operation completes successfully then '*error' is set to 'SIMPLICITY_NO_ERROR', and the 'cmr' array is filled in with the program's computed CMR.
+ *
+ * Precondition: NULL != error;
+ *               unsigned char cmr[32]
+ *               unsigned char program[program_len]
+ */
+extern bool simplicity_computeCmr( simplicity_err* error, unsigned char* cmr
+                                 , const unsigned char* program, size_t program_len);
+#endif

--- a/C/test.c
+++ b/C/test.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <getopt.h>
 #include <simplicity/elements/exec.h>
+#include <simplicity/cmr.h>
 #include "ctx8Pruned.h"
 #include "ctx8Unpruned.h"
 #include "dag.h"
@@ -369,6 +370,20 @@ static void test_elements(void) {
     if (tx1) {
       successes++;
       simplicity_err execResult;
+      {
+        unsigned char cmrResult[32];
+        if (simplicity_computeCmr(&execResult, cmrResult, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1) && IS_OK(execResult)) {
+          if (0 == memcmp(cmrResult, cmr, sizeof(unsigned char[8]))) {
+            successes++;
+          } else {
+            failures++;
+            printf("Unexpected CMR of elementsCheckSigHashAllTx1\n");
+          }
+        } else {
+          failures++;
+          printf("simplicity_computeCmr of elementsCheckSigHashAllTx1 unexpectedly produced %d.\n", execResult);
+        }
+      }
       {
         unsigned char imrResult[32];
         if (elements_simplicity_execSimplicity(&execResult, imrResult, tx1, 0, taproot, genesisHash, (elementsCheckSigHashAllTx1_cost + 999)/1000, amr, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1) && IS_OK(execResult)) {


### PR DESCRIPTION
Adding `simplicity_computeCmr` to compute the CMR of a given simplicity program. This is expected to be used in testing infrastructure, though it might also end up being used by wallet software.