### PR TITLE
Update return type of Bitcoin time lock jets

### DIFF
--- a/C/jets.c
+++ b/C/jets.c
@@ -1382,7 +1382,7 @@ bool sha_256_ctx_8_finalize(frameItem* dst, frameItem src, const txEnv* env) {
   return true;
 }
 
-/* parse_sequence : TWO^32 |- TWO^32 + TWO^32 */
+/* parse_sequence : TWO^32 |- Height + Time */
 bool parse_lock(frameItem* dst, frameItem src, const txEnv* env) {
   (void) env; /* env is unused. */
   uint_fast32_t nLockTime = read32(&src);
@@ -1391,7 +1391,7 @@ bool parse_lock(frameItem* dst, frameItem src, const txEnv* env) {
   return true;
 }
 
-/* parse_sequence : TWO^32 |- S (TWO^16 + TWO^16) */
+/* parse_sequence : TWO^32 |- S (Distance + Duration) */
 bool parse_sequence(frameItem* dst, frameItem src, const txEnv* env) {
   (void) env; /* env is unused. */
   uint_fast32_t nSequence = read32(&src);

--- a/Simplicity-TR.tm
+++ b/Simplicity-TR.tm
@@ -11247,7 +11247,7 @@
 
   <math|<rep|<text|<samp|'parse-lock'>>|>\<assign\><verbatim|<around*|[|110|]>><rsub|<2>>\<cdummy\><rep|<value|subsection-nr>|>\<cdummy\><rep|<value|subsubsection-nr>|>>
 
-  <math|<text|<samp|parse-lock>> :<2><rsup|32>\<vdash\><2><rsup|32>+<2><rsup|32>>
+  <math|<text|<samp|parse-lock>> :<2><rsup|32>\<vdash\>Height+Time>
 
   <subsubsection|<samp|parse-sequence>>
 
@@ -11255,7 +11255,7 @@
 
   <math|<rep|<text|<samp|'parse-sequence'>>|>\<assign\><verbatim|<around*|[|110|]>><rsub|<2>>\<cdummy\><rep|<value|subsection-nr>|>\<cdummy\><rep|<value|subsubsection-nr>|>>
 
-  <math|<text|<samp|parse-sequence>> :<2><rsup|32>\<vdash\><maybe><around*|(|<2><rsup|16>+<2><rsup|16>|)>>
+  <math|<text|<samp|parse-sequence>> :<2><rsup|32>\<vdash\><maybe><around*|(|Distance+Duration|)>>
 
   <section|<verbatim|111...: >Bitcoin Jets>
 


### PR DESCRIPTION
The updated function signatures are easier to read and structurally equivalent to the previous signatures.

(Please double-check if I got the output variants in the right order.)