### PR TITLE
TR: Fix broken jet references

### DIFF
--- a/Simplicity-TR.tm
+++ b/Simplicity-TR.tm
@@ -12410,7 +12410,7 @@
 
   \;
 
-  Returns <math|x> when <samp|is-final> returns <math|<math-tt|0><rsub|<2>>>
+  Returns <math|x> when <samp|tx-is-final> returns <math|<math-tt|0><rsub|<2>>>
   and <math|<around*|\<llbracket\>|<text|<samp|parse-lock>>|\<rrbracket\>>\<circ\><around*|\<llbracket\>|<text|<samp|lockTime>>|\<rrbracket\>>>
   returns <math|<injl|<around*|(|x|)>>>.
 
@@ -12426,7 +12426,7 @@
 
   \;
 
-  Returns <math|x> when <samp|is-final> returns <math|<math-tt|0><rsub|<2>>>
+  Returns <math|x> when <samp|tx-is-final> returns <math|<math-tt|0><rsub|<2>>>
   and <math|<around*|\<llbracket\>|<text|<samp|parse-lock>>|\<rrbracket\>>\<circ\><around*|\<llbracket\>|<text|<samp|lockTime>>|\<rrbracket\>>>
   returns <math|<injr|<around*|(|x|)>>>.
 

--- a/Simplicity-TR.tm
+++ b/Simplicity-TR.tm
@@ -11685,7 +11685,7 @@
     <item>The result of <samp|version> (Note: this is in big endian format)
     (4 bytes).
 
-    <item>The result of <samp|lock> (Note: this is in big endian format) (4
+    <item>The result of <samp|tx-lock-time> (Note: this is in big endian format) (4
     bytes).
 
     <item>The result of <samp|inputs-hash> (32 bytes).


### PR DESCRIPTION
Correctly reference the Elements locktime and is-final jets.