### PR TITLE
Fixup empty arrays in test vectors

### DIFF
--- a/C/ctx8Pruned.c
+++ b/C/ctx8Pruned.c
@@ -260,11 +260,10 @@ const unsigned char ctx8Pruned[] = {
 };
 
 const size_t sizeof_ctx8Pruned = sizeof(ctx8Pruned);
-const unsigned char ctx8Pruned_witness[] = {
+const unsigned char ctx8Pruned_witness[] = "";
 
-};
 
-const size_t sizeof_ctx8Pruned_witness = sizeof(ctx8Pruned_witness);
+const size_t sizeof_ctx8Pruned_witness = 0;
 
 /* The commitment Merkle root of the above ctx8Pruned Simplicity expression. */
 const uint32_t ctx8Pruned_cmr[] = {

--- a/C/ctx8Unpruned.c
+++ b/C/ctx8Unpruned.c
@@ -250,11 +250,10 @@ const unsigned char ctx8Unpruned[] = {
 };
 
 const size_t sizeof_ctx8Unpruned = sizeof(ctx8Unpruned);
-const unsigned char ctx8Unpruned_witness[] = {
+const unsigned char ctx8Unpruned_witness[] = "";
 
-};
 
-const size_t sizeof_ctx8Unpruned_witness = sizeof(ctx8Unpruned_witness);
+const size_t sizeof_ctx8Unpruned_witness = 0;
 
 /* The commitment Merkle root of the above ctx8Unpruned Simplicity expression. */
 const uint32_t ctx8Unpruned_cmr[] = {

--- a/C/hashBlock.c
+++ b/C/hashBlock.c
@@ -170,11 +170,10 @@ const unsigned char hashBlock[] = {
 };
 
 const size_t sizeof_hashBlock = sizeof(hashBlock);
-const unsigned char hashBlock_witness[] = {
+const unsigned char hashBlock_witness[] = "";
 
-};
 
-const size_t sizeof_hashBlock_witness = sizeof(hashBlock_witness);
+const size_t sizeof_hashBlock_witness = 0;
 
 /* The commitment Merkle root of the above hashBlock Simplicity expression. */
 const uint32_t hashBlock_cmr[] = {

--- a/Haskell-Generate/GenTests.hs
+++ b/Haskell-Generate/GenTests.hs
@@ -75,8 +75,14 @@ showComment wj txt = unlines $ ["/* A length-prefixed encoding of the following 
 
 showBinary name bin = unlines $ start ++ [intercalate ",\n" chunks] ++ finish
  where
-  start = ["const unsigned char "++name++"[] = {"]
-  finish = ["};", "", "const size_t sizeof_"++name++" = sizeof("++name++");"]
+  start = ["const unsigned char "++name++"[] = " ++ open]
+  open | null bin = "\"\";"
+       | otherwise = "{"
+  finish = close ++ ["", "const size_t sizeof_"++name++" = "++sizeof++";"]
+  close | null bin = []
+        | otherwise = ["};"]
+  sizeof | null bin = "0"
+         | otherwise = "sizeof("++name++")"
   chunks = ("  "++) . intercalate ", " <$> chunksOf 20 (showByte <$> bin)
   showByte b = "0x" ++ padding ++ t
    where


### PR DESCRIPTION
Arrays cannot be of zero size in C.

Normally I would change them to NULL pointers, however one cannot assign a NULL value to an array.  I could, and maybe should, change the header so that these values are pointers and not array, but if I were to do that, I ought to change all of the types of the test vectors to be pointers, in order to be consistent. In which case to assign an array to the pointer I'd have to use something like a compound literal.

That seems like a big pain for just test vectors, so for now we are just going to put a null character into what should be empty arrays and explicity set their corresponding size value to 0.