### PR TITLE
Fix some technical C typing issues

### DIFF
--- a/C/cmr.c
+++ b/C/cmr.c
@@ -26,13 +26,13 @@ bool simplicity_computeCmr( simplicity_err* error, unsigned char* cmr
 
   bitstream stream = initializeBitstream(program, program_len);
   dag_node* dag = NULL;
-  int32_t dag_len = simplicity_decodeMallocDag(&dag, NULL, &stream);
+  int_fast32_t dag_len = simplicity_decodeMallocDag(&dag, NULL, &stream);
   if (dag_len <= 0) {
     simplicity_assert(dag_len < 0);
-    *error = dag_len;
+    *error = (simplicity_err)dag_len;
   } else {
     simplicity_assert(NULL != dag);
-    simplicity_assert((size_t)dag_len <= DAG_LEN_MAX);
+    simplicity_assert((uint_fast32_t)dag_len <= DAG_LEN_MAX);
     *error = simplicity_closeBitstream(&stream);
     sha256_fromMidstate(cmr, dag[dag_len-1].cmr.s);
   }

--- a/C/dag.c
+++ b/C/dag.c
@@ -156,7 +156,7 @@ sha256_midstate simplicity_computeWordCMR(const bitstring* value, size_t n) {
  * Precondition: dag_node dag[i + 1] and 'dag' is well-formed.
  *               dag[i].'tag' \notin {HIDDEN, JET, WORD}
  */
-void simplicity_computeCommitmentMerkleRoot(dag_node* dag, const size_t i) {
+void simplicity_computeCommitmentMerkleRoot(dag_node* dag, const uint_fast32_t i) {
   uint32_t block[16] = {0};
   size_t j = 8;
 
@@ -200,7 +200,7 @@ void simplicity_computeCommitmentMerkleRoot(dag_node* dag, const size_t i) {
  * Precondition: sha256_midstate imr[len];
  *               dag_node dag[len] and 'dag' is well-typed with 'type_dag' and contains witnesses.
  */
-static void computeIdentityMerkleRoot(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const size_t len) {
+static void computeIdentityMerkleRoot(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const uint_fast32_t len) {
   /* Pass 1 */
   for (size_t i = 0; i < len; ++i) {
     uint32_t block[16] = {0};
@@ -271,8 +271,8 @@ static void computeIdentityMerkleRoot(sha256_midstate* imr, const dag_node* dag,
  *               dag_node dag[len] and 'dag' has witness data and is well-typed with 'type_dag'.
  * Postconditon: analyses analysis[len] contains the annotated Merkle roots of each subexpressions of 'dag'.
  */
-void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* dag, const type* type_dag, const size_t len) {
-  for (size_t i = 0; i < len; ++i) {
+void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* dag, const type* type_dag, const uint_fast32_t len) {
+  for (uint_fast32_t i = 0; i < len; ++i) {
     uint32_t block[16] = {0};
 
     /* For jets, their annotated Merkle root is the same as their commitment Merkle root. */
@@ -378,9 +378,9 @@ void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* d
  *
  * Precondition: dag_node dag[len] and 'dag' is well-formed.
  */
-simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const size_t len) {
-  size_t bottom = 0;
-  size_t top = len-1; /* Underflow is checked below. */
+simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const uint_fast32_t len) {
+  uint_fast32_t bottom = 0;
+  uint_fast32_t top = len-1; /* Underflow is checked below. */
 
   if (!len) {
     simplicity_assert(false); /* A well-formed dag has non-zero length */
@@ -403,7 +403,7 @@ simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const size_t len) 
      */
 
     /* Check first child. */
-    size_t child = dag[top].child[0];
+    uint_fast32_t child = dag[top].child[0];
     switch (dag[top].tag) {
      case ASSERTL:
      case ASSERTR:
@@ -482,9 +482,9 @@ simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const size_t len) 
  * Postcondition: dag_node dag[len] and 'dag' has witness data and is well-typed with 'type_dag'
  *                  when the result is 'SIMPLICITY_NO_ERROR';
  */
-simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const size_t len, bitstream *witness) {
+simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const uint_fast32_t len, bitstream *witness) {
   static_assert(CELLS_MAX <= 0x80000000, "CELLS_MAX is too large.");
-  for (size_t i = 0; i < len; ++i) {
+  for (uint_fast32_t i = 0; i < len; ++i) {
     if (WITNESS == dag[i].tag) {
       if (CELLS_MAX < type_dag[WITNESS_B(dag, type_dag, i)].bitSize) return SIMPLICITY_ERR_EXEC_MEMORY;
       if (witness->len <= 0) {
@@ -571,8 +571,9 @@ simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const s
  *
  * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' and contains witnesses.
  */
-simplicity_err simplicity_verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const size_t dag_len) {
+simplicity_err simplicity_verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const uint_fast32_t dag_len) {
   simplicity_assert(0 < dag_len);
+  simplicity_assert(dag_len <= DAG_LEN_MAX);
   sha256_midstate* imr_buf = simplicity_malloc((size_t)dag_len * sizeof(sha256_midstate));
   if (!imr_buf) return SIMPLICITY_ERR_MALLOC;
 

--- a/C/dag.h
+++ b/C/dag.h
@@ -115,7 +115,7 @@ typedef struct dag_node {
   jet_ptr jet;
   sha256_midstate cmr;
   union {
-    size_t aux; /* Used as scratch space for verifyCanonicalOrder. */
+    uint_fast32_t aux; /* Used as scratch space for verifyCanonicalOrder. */
     struct {
        size_t sourceType, targetType;
     };
@@ -125,7 +125,7 @@ typedef struct dag_node {
       size_t sourceIx;
     };
     struct {
-      size_t child[2];
+      uint_fast32_t child[2];
     };
     bitstring compactValue;
   };
@@ -334,7 +334,7 @@ typedef struct analyses {
  * Precondition: dag_node dag[i + 1] and 'dag' is well-formed.
  *               dag[i].'tag' \notin {HIDDEN, JET, WORD}
  */
-void simplicity_computeCommitmentMerkleRoot(dag_node* dag, size_t i);
+void simplicity_computeCommitmentMerkleRoot(dag_node* dag, uint_fast32_t i);
 
 /* Given a well-typed dag representing a Simplicity expression, compute the annotated Merkle roots of all subexpressions.
  * For all 'i', 0 <= 'i' < 'len', 'analysis[i].annotatedMerkleRoot' will be the AMR of the subexpression denoted by the slice
@@ -347,7 +347,7 @@ void simplicity_computeCommitmentMerkleRoot(dag_node* dag, size_t i);
  *               dag_node dag[len] and 'dag' has witness data and is well-typed with 'type_dag'.
  * Postconditon: analyses analysis[len] contains the annotated Merkle roots of each subexpressions of 'dag'.
  */
-void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* dag, const type* type_dag, size_t len);
+void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* dag, const type* type_dag, uint_fast32_t len);
 
 /* Verifies that the 'dag' is in canonical order, meaning that nodes under the left branches have lower indices than nodes under
  * right branches, with the exception that nodes under right braches may (cross-)reference identical nodes that already occur under
@@ -360,7 +360,7 @@ void simplicity_computeAnnotatedMerkleRoot(analyses* analysis, const dag_node* d
  *
  * Precondition: dag_node dag[len] and 'dag' is well-formed.
  */
-simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const size_t len);
+simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const uint_fast32_t len);
 
 /* This function fills in the 'WITNESS' nodes of a 'dag' with the data from 'witness'.
  * For each 'WITNESS' : A |- B expression in 'dag', the bits from the 'witness' bitstring are decoded in turn
@@ -375,7 +375,7 @@ simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const size_t len);
  * Postcondition: dag_node dag[len] and 'dag' has witness data and is well-typed with 'type_dag'
  *                  when the result is 'SIMPLICITY_NO_ERROR';
  */
-simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const size_t len, bitstream *witness);
+simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const uint_fast32_t len, bitstream *witness);
 
 /* Verifies that identity Merkle roots of every subexpression in a well-typed 'dag' with witnesses are all unique,
  * including that each hidden root hash for every 'HIDDEN' node is unique.
@@ -388,6 +388,6 @@ simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const s
  *
  * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' and contains witnesses.
  */
-simplicity_err simplicity_verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const size_t dag_len);
+simplicity_err simplicity_verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const uint_fast32_t dag_len);
 
 #endif

--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -55,7 +55,7 @@ static simplicity_err getHash(sha256_midstate* result, bitstream* stream) {
  *               i < 2^31 - 1
  *               NULL != stream
  */
-static simplicity_err decodeNode(dag_node* dag, size_t i, bitstream* stream) {
+static simplicity_err decodeNode(dag_node* dag, uint_fast32_t i, bitstream* stream) {
   int32_t bit = read1Bit(stream);
   if (bit < 0) return (simplicity_err)bit;
   dag[i] = (dag_node){0};
@@ -85,8 +85,8 @@ static simplicity_err decodeNode(dag_node* dag, size_t i, bitstream* stream) {
     for (int32_t j = 0; j < 2 - code; ++j) {
       int32_t ix = simplicity_decodeUptoMaxInt(stream);
       if (ix < 0) return (simplicity_err)ix;
-      if (i < (uint32_t)ix) return SIMPLICITY_ERR_DATA_OUT_OF_RANGE;
-      dag[i].child[j] = i - (uint32_t)ix;
+      if (i < (uint_fast32_t)ix) return SIMPLICITY_ERR_DATA_OUT_OF_RANGE;
+      dag[i].child[j] = i - (uint_fast32_t)ix;
     }
     switch (code) {
      case 0:
@@ -153,8 +153,8 @@ static simplicity_err decodeNode(dag_node* dag, size_t i, bitstream* stream) {
  *               len < 2^31
  *               NULL != stream
  */
-static simplicity_err decodeDag(dag_node* dag, const size_t len, combinator_counters* census, bitstream* stream) {
-  for (size_t i = 0; i < len; ++i) {
+static simplicity_err decodeDag(dag_node* dag, const uint_fast32_t len, combinator_counters* census, bitstream* stream) {
+  for (uint_fast32_t i = 0; i < len; ++i) {
     simplicity_err error = decodeNode(dag, i, stream);
     if (!IS_OK(error)) return error;
 
@@ -186,7 +186,7 @@ static simplicity_err decodeDag(dag_node* dag, const size_t len, combinator_coun
  *                          of the function is positive and when NULL != census;
  *                NULL == *dag when the return value is negative.
  */
-int32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* stream) {
+int_fast32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* stream) {
   *dag = NULL;
   int32_t dagLen = simplicity_decodeUptoMaxInt(stream);
   if (dagLen <= 0) return dagLen;
@@ -199,12 +199,12 @@ int32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, 
   if (!*dag) return SIMPLICITY_ERR_MALLOC;
 
   if (census) *census = (combinator_counters){0};
-  simplicity_err error = decodeDag(*dag, (size_t)dagLen, census, stream);
+  simplicity_err error = decodeDag(*dag, (uint_fast32_t)dagLen, census, stream);
 
   if (IS_OK(error)) {
     error = HIDDEN == (*dag)[dagLen - 1].tag
           ? SIMPLICITY_ERR_HIDDEN_ROOT
-          : simplicity_verifyCanonicalOrder(*dag, (size_t)(dagLen));
+          : simplicity_verifyCanonicalOrder(*dag, (uint_fast32_t)(dagLen));
   }
 
   if (IS_OK(error)) {
@@ -212,6 +212,6 @@ int32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, 
   } else {
     simplicity_free(*dag);
     *dag = NULL;
-    return (int32_t)error;
+    return (int_fast32_t)error;
   }
 }

--- a/C/deserialize.h
+++ b/C/deserialize.h
@@ -28,6 +28,6 @@
  *                          of the function is positive and when NULL != census;
  *                NULL == *dag when the return value is negative.
  */
-int32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* stream);
+int_fast32_t simplicity_decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* stream);
 
 #endif

--- a/C/jets.c
+++ b/C/jets.c
@@ -1117,7 +1117,7 @@ static void div_mod_96_64(uint_fast32_t *q, uint_fast64_t *r,
   uint_fast64_t estQ = ah / bh;
 
   /* Precondition 1 guarentees Q is 32-bits, if estQ is greater than UINT32_MAX, then reduce our initial estimated quotient to UINT32_MAX. */
-  *q = estQ <= UINT32_MAX ? estQ : UINT32_MAX;
+  *q = estQ <= UINT32_MAX ? (uint_fast32_t)estQ : UINT32_MAX;
 
   /* *q * bh <= estQ * bh <= ah */
   uint_fast64_t rh = ah - 1u * *q * bh;

--- a/C/primitive/elements/env.c
+++ b/C/primitive/elements/env.c
@@ -351,7 +351,7 @@ extern transaction* simplicity_elements_mallocTransaction(const rawTransaction* 
   /* Multiply by (size_t)1 to disable type-limits warning. */
   if (SIZE_MAX / sizeof(opcode) < (size_t)1 * totalNullDataCodes) return NULL;
   if (SIZE_MAX - allocationSize < totalNullDataCodes * sizeof(opcode)) return NULL;
-  allocationSize += totalNullDataCodes * sizeof(opcode);
+  allocationSize += (size_t)totalNullDataCodes * sizeof(opcode);
 
   char *allocation = simplicity_malloc(allocationSize);
   if (!allocation) return NULL;

--- a/C/primitive/elements/exec.c
+++ b/C/primitive/elements/exec.c
@@ -52,7 +52,7 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
 
   combinator_counters census;
   dag_node* dag = NULL;
-  int32_t dag_len;
+  int_fast32_t dag_len;
   sha256_midstate amr_hash, genesis_hash;
 
   if (amr) sha256_toMidstate(amr_hash.s, amr);
@@ -63,11 +63,11 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
     dag_len = simplicity_decodeMallocDag(&dag, &census, &stream);
     if (dag_len <= 0) {
       simplicity_assert(dag_len < 0);
-      *error = dag_len;
+      *error = (simplicity_err)dag_len;
       return IS_PERMANENT(*error);
     }
     simplicity_assert(NULL != dag);
-    simplicity_assert((size_t)dag_len <= DAG_LEN_MAX);
+    simplicity_assert((uint_fast32_t)dag_len <= DAG_LEN_MAX);
     *error = simplicity_closeBitstream(&stream);
   }
 
@@ -79,7 +79,7 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
 
   if (IS_OK(*error)) {
     type* type_dag = NULL;
-    *error = simplicity_mallocTypeInference(&type_dag, dag, (size_t)dag_len, &census);
+    *error = simplicity_mallocTypeInference(&type_dag, dag, (uint_fast32_t)dag_len, &census);
     if (IS_OK(*error)) {
       simplicity_assert(NULL != type_dag);
       if (0 != dag[dag_len-1].sourceType || 0 != dag[dag_len-1].targetType) {
@@ -88,7 +88,7 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
     }
     if (IS_OK(*error)) {
       bitstream witness_stream = initializeBitstream(witness, witness_len);
-      *error = simplicity_fillWitnessData(dag, type_dag, (size_t)dag_len, &witness_stream);
+      *error = simplicity_fillWitnessData(dag, type_dag, (uint_fast32_t)dag_len, &witness_stream);
       if (IS_OK(*error)) {
         *error = simplicity_closeBitstream(&witness_stream);
         if (SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES == *error) *error = SIMPLICITY_ERR_WITNESS_TRAILING_BYTES;
@@ -100,7 +100,7 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
       static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(sha256_midstate), "imr_buf array too large.");
       static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
       static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "imr_buf array index does nto fit in uint32_t.");
-      *error = simplicity_verifyNoDuplicateIdentityRoots(&imr_buf, dag, type_dag, (size_t)dag_len);
+      *error = simplicity_verifyNoDuplicateIdentityRoots(&imr_buf, dag, type_dag, (uint_fast32_t)dag_len);
       if (IS_OK(*error) && imr) sha256_fromMidstate(imr, imr_buf.s);
     }
     if (IS_OK(*error) && amr) {
@@ -109,7 +109,7 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
       static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "analysis array index does nto fit in uint32_t.");
       analyses *analysis = simplicity_malloc((size_t)dag_len * sizeof(analyses));
       if (analysis) {
-        simplicity_computeAnnotatedMerkleRoot(analysis, dag, type_dag, (size_t)dag_len);
+        simplicity_computeAnnotatedMerkleRoot(analysis, dag, type_dag, (uint_fast32_t)dag_len);
         if (0 != memcmp(amr_hash.s, analysis[dag_len-1].annotatedMerkleRoot.s, sizeof(uint32_t[8]))) {
           *error = SIMPLICITY_ERR_AMR;
         }

--- a/C/primitive/elements/jets.c
+++ b/C/primitive/elements/jets.c
@@ -157,7 +157,7 @@ static uint_fast16_t lockDistance(const transaction* tx) {
 }
 
 static uint_fast16_t lockDuration(const transaction* tx) {
-  return 2 <= tx->version ? (uint_fast32_t)tx->lockDuration : 0;
+  return 2 <= tx->version ? tx->lockDuration : 0;
 }
 
 static bool isFee(const sigOutput* output) {

--- a/C/rsort.c
+++ b/C/rsort.c
@@ -267,7 +267,7 @@ int simplicity_hasDuplicates(const sha256_midstate* a, uint_fast32_t len) {
   static_assert(sizeof(a->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding.");
   static_assert(DAG_LEN_MAX <= UINT32_MAX, "DAG_LEN_MAX does not fit in uint32_t.");
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(const sha256_midstate*), "perm array too large.");
-  simplicity_assert(len <= SIZE_MAX / sizeof(const sha256_midstate*));
+  simplicity_assert((size_t)len <= SIZE_MAX / sizeof(const sha256_midstate*));
   const sha256_midstate **perm = simplicity_malloc(len * sizeof(const sha256_midstate*));
   uint32_t *stack = simplicity_malloc(((CHAR_COUNT - 1)*(sizeof((*perm)->s)) + 1) * sizeof(uint32_t));
   int result = perm && stack ? 0 : -1;

--- a/C/secp256k1/util.h
+++ b/C/secp256k1/util.h
@@ -170,7 +170,7 @@ static SECP256K1_INLINE int secp256k1_ctz64_var(uint64_t x) {
 #if (__has_builtin(__builtin_ctzl) || SECP256K1_GNUC_PREREQ(3,4))
     /* If the unsigned long type is sufficient to represent the largest uint64_t, consider __builtin_ctzl. */
     if (((unsigned long)UINT64_MAX) == UINT64_MAX) {
-        return __builtin_ctzl(x);
+        return __builtin_ctzl((unsigned long)x);
     }
 #endif
 #if (__has_builtin(__builtin_ctzll) || SECP256K1_GNUC_PREREQ(3,4))

--- a/C/test.c
+++ b/C/test.c
@@ -501,34 +501,34 @@ static sha256_midstate hashint(uint_fast32_t n) {
   return result;
 }
 
-static sha256_midstate rsort_no_duplicates(size_t i) {
+static sha256_midstate rsort_no_duplicates(uint_fast32_t i) {
   return hashint(i);
 }
 
-static sha256_midstate rsort_all_duplicates(size_t i) {
+static sha256_midstate rsort_all_duplicates(uint_fast32_t i) {
   (void)i;
   return hashint(0);
 }
 
-static sha256_midstate rsort_one_duplicate(size_t i) {
+static sha256_midstate rsort_one_duplicate(uint_fast32_t i) {
   return hashint(i ? i : 1);
 }
 
 /* Tests a worst-case conditions for stack usage in rsort. */
-static sha256_midstate rsort_diagonal(size_t i) {
+static sha256_midstate rsort_diagonal(uint_fast32_t i) {
   sha256_midstate result = {0};
   unsigned char *alias = (unsigned char *)(result.s);
-  for (size_t j = 0; j < sizeof(result.s); ++j) {
+  for (uint_fast32_t j = 0; j < sizeof(result.s); ++j) {
     alias[j] = j == i ? 0 : 0xff;
   }
   return result;
 }
 
-static void test_hasDuplicates(const char* name, int expected, sha256_midstate (*f)(size_t), size_t n) {
+static void test_hasDuplicates(const char* name, int expected, sha256_midstate (*f)(uint_fast32_t), uint_fast32_t n) {
   sha256_midstate hashes[n];
 
   printf("Test %s\n", name);
-  for(size_t i = 0; i < n; ++i) {
+  for(uint_fast32_t i = 0; i < n; ++i) {
     hashes[i] = f(i);
   }
 

--- a/C/typeInference.c
+++ b/C/typeInference.c
@@ -265,10 +265,10 @@ static size_t max_extra_vars(const combinator_counters* census) {
  *                    that are accessible from the 'arrow' array and 'bound_var' array.
  *                  and 'arrow' is a graph of bindings that satisfies the typing constraints of imposed by 'dag'.
  */
-static simplicity_err typeInference( unification_arrow* arrow, const dag_node* dag, const size_t len,
+static simplicity_err typeInference( unification_arrow* arrow, const dag_node* dag, const uint_fast32_t len,
                                      unification_var* extra_var, unification_var* bound_var, size_t word256_ix, size_t* bindings_used
                                    ) {
-  for (size_t i = 0; i < len; ++i) {
+  for (uint_fast32_t i = 0; i < len; ++i) {
     switch (dag[i].tag) {
       #define UNIFY(a, b) { if (!unify((a), (b), bindings_used)) return SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION; }
       #define APPLY_BINDING(a, b) { if (!applyBinding((a), (b), bindings_used)) return SIMPLICITY_ERR_TYPE_INFERENCE_UNIFICATION; }
@@ -559,7 +559,7 @@ static simplicity_err freezeTypes(type* type_dag, dag_node* dag, unification_arr
  *                     or 'dag' is well-typed with '*type_dag' and without witness values
  *                if the return value is not 'SIMPLICITY_NO_ERROR' then 'NULL == *type_dag'
  */
-simplicity_err simplicity_mallocTypeInference(type** type_dag, dag_node* dag, const size_t len, const combinator_counters* census) {
+simplicity_err simplicity_mallocTypeInference(type** type_dag, dag_node* dag, const uint_fast32_t len, const combinator_counters* census) {
   *type_dag = NULL;
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(unification_arrow), "arrow array too large.");
   static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");

--- a/C/typeInference.h
+++ b/C/typeInference.h
@@ -91,6 +91,6 @@ struct unification_var {
  *                     or 'dag' is well-typed with '*type_dag' and without witness values
  *                if the return value is not 'SIMPLICITY_NO_ERROR' then 'NULL == *type_dag'
  */
-simplicity_err simplicity_mallocTypeInference(type** type_dag, dag_node* dag, const size_t len, const combinator_counters* census);
+simplicity_err simplicity_mallocTypeInference(type** type_dag, dag_node* dag, const uint_fast32_t len, const combinator_counters* census);
 
 #endif


### PR DESCRIPTION
This PR fixes up the types and makes for error free compiling on 32-bit and other exotic systems.

Most of the commits don't even make change in the binary generated on 64-bit systems, but the last commit, which unfortunately also is the most complicated one, does change the binary by a little bit.