### PR TITLE
cabal install from ghc 9.4 not supported

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let hp = nixpkgs.haskell.packages.${ghc};
     cp = nixpkgs.${coqPackages};
  in rec
 {
-  haskell = haskellPackages.callPackage ./Simplicity.Haskell.nix {};
+  haskell = haskellPackages.callPackage ./Simplicity.Haskell.nix { cabal-install = nixpkgs.cabal-install; };
 
   haskellPackages = hp.override {
     overrides = self: super: {

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@
 let
   simplicity      = import ./. {inherit nixpkgs ghc coqPackages env withCoverage withProfiler withValgrind;};
   optional        = nixpkgs.lib.optional;
-  haskellDevTools = pkgs: with pkgs; [cabal-install hlint hasktags];
+  haskellDevTools = pkgs: with pkgs; [ nixpkgs.cabal-install hlint hasktags];
   haskellPkgs     = pkgs: simplicity.haskell.buildInputs ++ simplicity.haskell.propagatedBuildInputs ++ haskellDevTools pkgs;
   haskellDevEnv   = simplicity.haskellPackages.ghcWithPackages haskellPkgs;
   coqDevEnv       = [ nixpkgs.python3Packages.alectryon


### PR DESCRIPTION
The suggested workaround it to use cabal-install from nixpkgs rather than the one from the compiler package. See <https://github.com/NixOS/nixpkgs/commit/9919b666ab142a2b47ea153154f39301bd4b01d8>.