### PR TITLE
Identity hash

### DIFF
--- a/C/ctx8Pruned.c
+++ b/C/ctx8Pruned.c
@@ -270,8 +270,8 @@ const uint32_t ctx8Pruned_cmr[] = {
   0x7f11746fu, 0xb68fdaedu, 0x3cadda80u, 0xc7cd0245u, 0xa341b927u, 0xe98e60f8u, 0x745dc441u, 0xe11ce1a3u
 };
 
-/* The identity Merkle root of the above ctx8Pruned Simplicity expression. */
-const uint32_t ctx8Pruned_imr[] = {
+/* The identity hash of the root of the above ctx8Pruned Simplicity expression. */
+const uint32_t ctx8Pruned_ihr[] = {
   0x8e8742acu, 0x27f42d29u, 0xd87f5229u, 0x02bc0ae2u, 0xbcfc1298u, 0x1641a2ddu, 0x77091830u, 0xb79bf12du
 };
 

--- a/C/ctx8Pruned.h
+++ b/C/ctx8Pruned.h
@@ -18,8 +18,8 @@ extern const size_t sizeof_ctx8Pruned_witness;
 /* The commitment Merkle root of the above ctx8Pruned Simplicity expression. */
 extern const uint32_t ctx8Pruned_cmr[];
 
-/* The identity Merkle root of the above ctx8Pruned Simplicity expression. */
-extern const uint32_t ctx8Pruned_imr[];
+/* The identity hash of the root of the above ctx8Pruned Simplicity expression. */
+extern const uint32_t ctx8Pruned_ihr[];
 
 /* The annotated Merkle root of the above ctx8Pruned Simplicity expression. */
 extern const uint32_t ctx8Pruned_amr[];

--- a/C/ctx8Unpruned.c
+++ b/C/ctx8Unpruned.c
@@ -260,8 +260,8 @@ const uint32_t ctx8Unpruned_cmr[] = {
   0x7f11746fu, 0xb68fdaedu, 0x3cadda80u, 0xc7cd0245u, 0xa341b927u, 0xe98e60f8u, 0x745dc441u, 0xe11ce1a3u
 };
 
-/* The identity Merkle root of the above ctx8Unpruned Simplicity expression. */
-const uint32_t ctx8Unpruned_imr[] = {
+/* The identity hash of the root of the above ctx8Unpruned Simplicity expression. */
+const uint32_t ctx8Unpruned_ihr[] = {
   0x8e8742acu, 0x27f42d29u, 0xd87f5229u, 0x02bc0ae2u, 0xbcfc1298u, 0x1641a2ddu, 0x77091830u, 0xb79bf12du
 };
 

--- a/C/ctx8Unpruned.h
+++ b/C/ctx8Unpruned.h
@@ -18,8 +18,8 @@ extern const size_t sizeof_ctx8Unpruned_witness;
 /* The commitment Merkle root of the above ctx8Unpruned Simplicity expression. */
 extern const uint32_t ctx8Unpruned_cmr[];
 
-/* The identity Merkle root of the above ctx8Unpruned Simplicity expression. */
-extern const uint32_t ctx8Unpruned_imr[];
+/* The identity hash of the root of the above ctx8Unpruned Simplicity expression. */
+extern const uint32_t ctx8Unpruned_ihr[];
 
 /* The annotated Merkle root of the above ctx8Unpruned Simplicity expression. */
 extern const uint32_t ctx8Unpruned_amr[];

--- a/C/dag.h
+++ b/C/dag.h
@@ -377,17 +377,17 @@ simplicity_err simplicity_verifyCanonicalOrder(dag_node* dag, const uint_fast32_
  */
 simplicity_err simplicity_fillWitnessData(dag_node* dag, type* type_dag, const uint_fast32_t len, bitstream *witness);
 
-/* Verifies that identity Merkle roots of every subexpression in a well-typed 'dag' with witnesses are all unique,
+/* Verifies that identity hash of every subexpression in a well-typed 'dag' with witnesses are all unique,
  * including that each hidden root hash for every 'HIDDEN' node is unique.
  *
- * if 'imr' is not NULL, then '*imr' is set to the identity Merkle root of the 'dag'.
+ * if 'ihr' is not NULL, then '*ihr' is set to the identity hash of the root of the 'dag'.
  *
  * If malloc fails, returns 'SIMPLICITY_ERR_MALLOC'.
- * If all the identity Merkle roots (and hidden roots) are all unique, returns 'SIMPLICITY_NO_ERROR'.
+ * If all the identity hahes (and hidden roots) are all unique, returns 'SIMPLICITY_NO_ERROR'.
  * Otherwise returns 'SIMPLICITY_ERR_UNSHARED_SUBEXPRESSION'.
  *
  * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' and contains witnesses.
  */
-simplicity_err simplicity_verifyNoDuplicateIdentityRoots(sha256_midstate* imr, const dag_node* dag, const type* type_dag, const uint_fast32_t dag_len);
+simplicity_err simplicity_verifyNoDuplicateIdentityHashes(sha256_midstate* ihr, const dag_node* dag, const type* type_dag, const uint_fast32_t dag_len);
 
 #endif

--- a/C/hashBlock.c
+++ b/C/hashBlock.c
@@ -180,8 +180,8 @@ const uint32_t hashBlock_cmr[] = {
   0xa07dd7d8u, 0x22aed1adu, 0x40576a7au, 0x69fa1082u, 0x52d3dd89u, 0x539b1e4eu, 0x1f567851u, 0x9abf54e5u
 };
 
-/* The identity Merkle root of the above hashBlock Simplicity expression. */
-const uint32_t hashBlock_imr[] = {
+/* The identity hash of the root of the above hashBlock Simplicity expression. */
+const uint32_t hashBlock_ihr[] = {
   0x609cc145u, 0x9375db72u, 0x8f2172c9u, 0x62807e31u, 0x61df4cceu, 0xd6592d2cu, 0x4e594a77u, 0x79ab3175u
 };
 

--- a/C/hashBlock.h
+++ b/C/hashBlock.h
@@ -16,8 +16,8 @@ extern const size_t sizeof_hashBlock_witness;
 /* The commitment Merkle root of the above hashBlock Simplicity expression. */
 extern const uint32_t hashBlock_cmr[];
 
-/* The identity Merkle root of the above hashBlock Simplicity expression. */
-extern const uint32_t hashBlock_imr[];
+/* The identity hash of the root of the above hashBlock Simplicity expression. */
+extern const uint32_t hashBlock_ihr[];
 
 /* The annotated Merkle root of the above hashBlock Simplicity expression. */
 extern const uint32_t hashBlock_amr[];

--- a/C/include/simplicity/elements/exec.h
+++ b/C/include/simplicity/elements/exec.h
@@ -19,19 +19,20 @@
  *
  * Otherwise '*error' is set to 'SIMPLICITY_NO_ERROR'.
  *
- * If 'imr != NULL' and '*error' is set to 'SIMPLICITY_NO_ERROR', then the identity Merkle root of the decoded expression is written to 'imr'.
- * Otherwise if 'imr != NULL'  and '*error' is not set to 'SIMPLCITY_NO_ERROR', then 'imr' may or may not be written to.
+ * If 'ihr != NULL' and '*error' is set to 'SIMPLICITY_NO_ERROR', then the identity hash of the root of the decoded expression is written to 'ihr'.
+ * Otherwise if 'ihr != NULL'  and '*error' is not set to 'SIMPLCITY_NO_ERROR', then 'ihr' may or may not be written to.
  *
  * Precondition: NULL != error;
- *               NULL != imr implies unsigned char imr[32]
+ *               NULL != ihr implies unsigned char ihr[32]
  *               NULL != tx;
  *               NULL != taproot;
  *               unsigned char genesisBlockHash[32]
+ *               0 <= budget;
  *               NULL != amr implies unsigned char amr[32]
  *               unsigned char program[program_len]
  *               unsigned char witness[witness_len]
  */
-extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* imr
+extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* ihr
                                               , const transaction* tx, uint_fast32_t ix, const tapEnv* taproot
                                               , const unsigned char* genesisBlockHash
                                               , int64_t budget

--- a/C/primitive/elements/checkSigHashAllTx1.c
+++ b/C/primitive/elements/checkSigHashAllTx1.c
@@ -28,8 +28,8 @@ const uint32_t elementsCheckSigHashAllTx1_cmr[] = {
   0xf3cd4537u, 0xd7ebb201u, 0x73220319u, 0x5b30b549u, 0xb8dc0c2cu, 0x6257b3a0u, 0xd53bedb0u, 0x8ea02874u
 };
 
-/* The identity Merkle root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
-const uint32_t elementsCheckSigHashAllTx1_imr[] = {
+/* The identity hash of the root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
+const uint32_t elementsCheckSigHashAllTx1_ihr[] = {
   0xd3a5130du, 0xf6abce06u, 0x51eb717au, 0x6dd04222u, 0xb7517651u, 0x9117ec5cu, 0x07bb9edbu, 0xac335e1bu
 };
 

--- a/C/primitive/elements/checkSigHashAllTx1.h
+++ b/C/primitive/elements/checkSigHashAllTx1.h
@@ -20,8 +20,8 @@ extern const size_t sizeof_elementsCheckSigHashAllTx1_witness;
 /* The commitment Merkle root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
 extern const uint32_t elementsCheckSigHashAllTx1_cmr[];
 
-/* The identity Merkle root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
-extern const uint32_t elementsCheckSigHashAllTx1_imr[];
+/* The identity hash of the root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
+extern const uint32_t elementsCheckSigHashAllTx1_ihr[];
 
 /* The annotated Merkle root of the above elementsCheckSigHashAllTx1 Simplicity expression. */
 extern const uint32_t elementsCheckSigHashAllTx1_amr[];

--- a/C/primitive/elements/exec.c
+++ b/C/primitive/elements/exec.c
@@ -22,11 +22,11 @@
  *
  * Otherwise '*error' is set to 'SIMPLICITY_NO_ERROR'.
  *
- * If 'imr != NULL' and '*error' is set to 'SIMPLICITY_NO_ERROR', then the identity Merkle root of the decoded expression is written to 'imr'.
- * Otherwise if 'imr != NULL'  and '*error' is not set to 'SIMPLCITY_NO_ERROR', then 'imr' may or may not be written to.
+ * If 'ihr != NULL' and '*error' is set to 'SIMPLICITY_NO_ERROR', then the identity hash of the root of the decoded expression is written to 'ihr'.
+ * Otherwise if 'ihr != NULL'  and '*error' is not set to 'SIMPLCITY_NO_ERROR', then 'ihr' may or may not be written to.
  *
  * Precondition: NULL != error;
- *               NULL != imr implies unsigned char imr[32]
+ *               NULL != ihr implies unsigned char ihr[32]
  *               NULL != tx;
  *               NULL != taproot;
  *               unsigned char genesisBlockHash[32]
@@ -35,7 +35,7 @@
  *               unsigned char program[program_len]
  *               unsigned char witness[witness_len]
  */
-extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* imr
+extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* ihr
                                               , const transaction* tx, uint_fast32_t ix, const tapEnv* taproot
                                               , const unsigned char* genesisBlockHash
                                               , int64_t budget
@@ -96,9 +96,9 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
       }
     }
     if (IS_OK(*error)) {
-      sha256_midstate imr_buf;
-      *error = simplicity_verifyNoDuplicateIdentityRoots(&imr_buf, dag, type_dag, (uint_fast32_t)dag_len);
-      if (IS_OK(*error) && imr) sha256_fromMidstate(imr, imr_buf.s);
+      sha256_midstate ihr_buf;
+      *error = simplicity_verifyNoDuplicateIdentityHashes(&ihr_buf, dag, type_dag, (uint_fast32_t)dag_len);
+      if (IS_OK(*error) && ihr) sha256_fromMidstate(ihr, ihr_buf.s);
     }
     if (IS_OK(*error) && amr) {
       static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(analyses), "analysis array too large.");

--- a/C/primitive/elements/exec.c
+++ b/C/primitive/elements/exec.c
@@ -97,9 +97,6 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
     }
     if (IS_OK(*error)) {
       sha256_midstate imr_buf;
-      static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(sha256_midstate), "imr_buf array too large.");
-      static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
-      static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "imr_buf array index does nto fit in uint32_t.");
       *error = simplicity_verifyNoDuplicateIdentityRoots(&imr_buf, dag, type_dag, (uint_fast32_t)dag_len);
       if (IS_OK(*error) && imr) sha256_fromMidstate(imr, imr_buf.s);
     }

--- a/C/schnorr0.c
+++ b/C/schnorr0.c
@@ -29,8 +29,8 @@ const uint32_t schnorr0_cmr[] = {
   0x8a9e9767u, 0x6b24be77u, 0x97d9ee0bu, 0xf32dd76bu, 0xcd78028eu, 0x973025f7u, 0x85eae8dcu, 0x91c8a0dau
 };
 
-/* The identity Merkle root of the above schnorr0 Simplicity expression. */
-const uint32_t schnorr0_imr[] = {
+/* The identity hash of the root of the above schnorr0 Simplicity expression. */
+const uint32_t schnorr0_ihr[] = {
   0xad7c38b1u, 0x6b912964u, 0x6dc89b52u, 0xcff144deu, 0x94a80e38u, 0x3c4983b5u, 0x3de65e35u, 0x75abcf38u
 };
 

--- a/C/schnorr0.h
+++ b/C/schnorr0.h
@@ -20,8 +20,8 @@ extern const size_t sizeof_schnorr0_witness;
 /* The commitment Merkle root of the above schnorr0 Simplicity expression. */
 extern const uint32_t schnorr0_cmr[];
 
-/* The identity Merkle root of the above schnorr0 Simplicity expression. */
-extern const uint32_t schnorr0_imr[];
+/* The identity hash of the root of the above schnorr0 Simplicity expression. */
+extern const uint32_t schnorr0_ihr[];
 
 /* The annotated Merkle root of the above schnorr0 Simplicity expression. */
 extern const uint32_t schnorr0_amr[];

--- a/C/schnorr6.c
+++ b/C/schnorr6.c
@@ -29,8 +29,8 @@ const uint32_t schnorr6_cmr[] = {
   0x83b6b5bcu, 0xc9bdc956u, 0xaf326376u, 0xf201aa7au, 0x2e65bb9eu, 0xedca6a06u, 0x65976452u, 0x5203cf68u
 };
 
-/* The identity Merkle root of the above schnorr6 Simplicity expression. */
-const uint32_t schnorr6_imr[] = {
+/* The identity hash of the root of the above schnorr6 Simplicity expression. */
+const uint32_t schnorr6_ihr[] = {
   0x53acece2u, 0xa5e61e36u, 0xd6c57f92u, 0x4cff9c45u, 0x0a283badu, 0x853aab59u, 0xebdf384du, 0x26264fefu
 };
 

--- a/C/schnorr6.h
+++ b/C/schnorr6.h
@@ -20,8 +20,8 @@ extern const size_t sizeof_schnorr6_witness;
 /* The commitment Merkle root of the above schnorr6 Simplicity expression. */
 extern const uint32_t schnorr6_cmr[];
 
-/* The identity Merkle root of the above schnorr6 Simplicity expression. */
-extern const uint32_t schnorr6_imr[];
+/* The identity hash of the root of the above schnorr6 Simplicity expression. */
+extern const uint32_t schnorr6_ihr[];
 
 /* The annotated Merkle root of the above schnorr6 Simplicity expression. */
 extern const uint32_t schnorr6_amr[];

--- a/C/test.c
+++ b/C/test.c
@@ -127,13 +127,13 @@ static void test_hashBlock(void) {
         }
       }
       {
-        sha256_midstate imr;
-        if (IS_OK(simplicity_verifyNoDuplicateIdentityRoots(&imr, dag, type_dag, (uint_fast32_t)len)) &&
-            0 == memcmp(hashBlock_imr, imr.s, sizeof(uint32_t[8]))) {
+        sha256_midstate ihr;
+        if (IS_OK(simplicity_verifyNoDuplicateIdentityHashes(&ihr, dag, type_dag, (uint_fast32_t)len)) &&
+            0 == memcmp(hashBlock_ihr, ihr.s, sizeof(uint32_t[8]))) {
           successes++;
         } else {
           failures++;
-          printf("Unexpected IMR of hashblock\n");
+          printf("Unexpected IHR of hashblock\n");
         }
       }
 
@@ -187,7 +187,7 @@ static void test_hashBlock(void) {
 
 static void test_program(char* name, const unsigned char* program, size_t program_len, const unsigned char* witness, size_t witness_len,
                          simplicity_err expectedResult, const uint32_t* expectedCMR,
-                         const uint32_t* expectedIMR, const uint32_t* expectedAMR, const ubounded *expectedCost) {
+                         const uint32_t* expectedIHR, const uint32_t* expectedAMR, const ubounded *expectedCost) {
   printf("Test %s\n", name);
   dag_node* dag;
   combinator_counters census;
@@ -253,13 +253,13 @@ static void test_program(char* name, const unsigned char* program, size_t progra
         }
       }
       {
-        sha256_midstate imr;
-        if (IS_OK(simplicity_verifyNoDuplicateIdentityRoots(&imr, dag, type_dag, (uint_fast32_t)len)) &&
-            (!expectedIMR || 0 == memcmp(expectedIMR, imr.s, sizeof(uint32_t[8])))) {
+        sha256_midstate ihr;
+        if (IS_OK(simplicity_verifyNoDuplicateIdentityHashes(&ihr, dag, type_dag, (uint_fast32_t)len)) &&
+            (!expectedIHR || 0 == memcmp(expectedIHR, ihr.s, sizeof(uint32_t[8])))) {
           successes++;
         } else {
           failures++;
-          printf("Unexpected IMR.\n");
+          printf("Unexpected IHR.\n");
         }
       }
       if (expectedCost) {
@@ -404,15 +404,15 @@ static void test_elements(void) {
         }
       }
       {
-        unsigned char imrResult[32];
-        if (simplicity_elements_execSimplicity(&execResult, imrResult, tx1, 0, taproot, genesisHash, (elementsCheckSigHashAllTx1_cost + 999)/1000, amr, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1, elementsCheckSigHashAllTx1_witness, sizeof_elementsCheckSigHashAllTx1_witness) && IS_OK(execResult)) {
-          sha256_midstate imr;
-          sha256_toMidstate(imr.s, imrResult);
-          if (0 == memcmp(imr.s, elementsCheckSigHashAllTx1_imr, sizeof(uint32_t[8]))) {
+        unsigned char ihrResult[32];
+        if (simplicity_elements_execSimplicity(&execResult, ihrResult, tx1, 0, taproot, genesisHash, (elementsCheckSigHashAllTx1_cost + 999)/1000, amr, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1, elementsCheckSigHashAllTx1_witness, sizeof_elementsCheckSigHashAllTx1_witness) && IS_OK(execResult)) {
+          sha256_midstate ihr;
+          sha256_toMidstate(ihr.s, ihrResult);
+          if (0 == memcmp(ihr.s, elementsCheckSigHashAllTx1_ihr, sizeof(uint32_t[8]))) {
             successes++;
           } else {
             failures++;
-            printf("Unexpected IMR of elementsCheckSigHashAllTx1\n");
+            printf("Unexpected IHR of elementsCheckSigHashAllTx1\n");
           }
         } else {
           failures++;
@@ -421,7 +421,7 @@ static void test_elements(void) {
         if (elementsCheckSigHashAllTx1_cost){
           /* test the same transaction without adequate budget. */
           simplicity_assert(elementsCheckSigHashAllTx1_cost);
-          if (simplicity_elements_execSimplicity(&execResult, imrResult, tx1, 0, taproot, genesisHash, (elementsCheckSigHashAllTx1_cost - 1)/1000, amr, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1, elementsCheckSigHashAllTx1_witness, sizeof_elementsCheckSigHashAllTx1_witness) && SIMPLICITY_ERR_EXEC_BUDGET == execResult) {
+          if (simplicity_elements_execSimplicity(&execResult, ihrResult, tx1, 0, taproot, genesisHash, (elementsCheckSigHashAllTx1_cost - 1)/1000, amr, elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1, elementsCheckSigHashAllTx1_witness, sizeof_elementsCheckSigHashAllTx1_witness) && SIMPLICITY_ERR_EXEC_BUDGET == execResult) {
             successes++;
           } else {
             failures++;
@@ -664,16 +664,16 @@ int main(int argc, char **argv) {
   test_hasDuplicates("hasDuplicates one duplicate testcase", 1, rsort_one_duplicate, 10000);
   test_hasDuplicates("hasDuplicates diagonal testcase", 0, rsort_diagonal, 33);
 
-  test_program("ctx8Pruned", ctx8Pruned, sizeof_ctx8Pruned, ctx8Pruned_witness, sizeof_ctx8Pruned_witness, SIMPLICITY_NO_ERROR, ctx8Pruned_cmr, ctx8Pruned_imr, ctx8Pruned_amr, &ctx8Pruned_cost);
-  test_program("ctx8Unpruned", ctx8Unpruned, sizeof_ctx8Unpruned, ctx8Unpruned_witness, sizeof_ctx8Unpruned_witness, SIMPLICITY_ERR_ANTIDOS, ctx8Unpruned_cmr, ctx8Unpruned_imr, ctx8Unpruned_amr, &ctx8Unpruned_cost);
+  test_program("ctx8Pruned", ctx8Pruned, sizeof_ctx8Pruned, ctx8Pruned_witness, sizeof_ctx8Pruned_witness, SIMPLICITY_NO_ERROR, ctx8Pruned_cmr, ctx8Pruned_ihr, ctx8Pruned_amr, &ctx8Pruned_cost);
+  test_program("ctx8Unpruned", ctx8Unpruned, sizeof_ctx8Unpruned, ctx8Unpruned_witness, sizeof_ctx8Unpruned_witness, SIMPLICITY_ERR_ANTIDOS, ctx8Unpruned_cmr, ctx8Unpruned_ihr, ctx8Unpruned_amr, &ctx8Unpruned_cost);
   if (0 == memcmp(ctx8Pruned_cmr, ctx8Unpruned_cmr, sizeof(uint32_t[8]))) {
     successes++;
   } else {
     failures++;
     printf("Pruned and Unpruned CMRs are not the same.\n");
   }
-  test_program("schnorr0", schnorr0, sizeof_schnorr0, schnorr0_witness, sizeof_schnorr0_witness, SIMPLICITY_NO_ERROR, schnorr0_cmr, schnorr0_imr, schnorr0_amr, &schnorr0_cost);
-  test_program("schnorr6", schnorr6, sizeof_schnorr6, schnorr6_witness, sizeof_schnorr6_witness, SIMPLICITY_ERR_EXEC_JET, schnorr6_cmr, schnorr6_imr, schnorr6_amr, &schnorr0_cost);
+  test_program("schnorr0", schnorr0, sizeof_schnorr0, schnorr0_witness, sizeof_schnorr0_witness, SIMPLICITY_NO_ERROR, schnorr0_cmr, schnorr0_ihr, schnorr0_amr, &schnorr0_cost);
+  test_program("schnorr6", schnorr6, sizeof_schnorr6, schnorr6_witness, sizeof_schnorr6_witness, SIMPLICITY_ERR_EXEC_JET, schnorr6_cmr, schnorr6_ihr, schnorr6_amr, &schnorr0_cost);
   test_program("typeSkipTest", typeSkipTest, sizeof_typeSkipTest, typeSkipTest_witness, sizeof_typeSkipTest_witness, SIMPLICITY_NO_ERROR, NULL, NULL, NULL, NULL);
   test_elements();
   regression_tests();

--- a/C/typeSkipTest.c
+++ b/C/typeSkipTest.c
@@ -48,8 +48,8 @@ const uint32_t typeSkipTest_cmr[] = {
   0x2a791cd8u, 0xf1e2beeau, 0x883e53f2u, 0xce36db2bu, 0x246b3156u, 0xcc40f91bu, 0xb2f59059u, 0xb601ac4au
 };
 
-/* The identity Merkle root of the above typeSkipTest Simplicity expression. */
-const uint32_t typeSkipTest_imr[] = {
+/* The identity hash of the root of the above typeSkipTest Simplicity expression. */
+const uint32_t typeSkipTest_ihr[] = {
   0xbadac773u, 0x19e9cabau, 0x7fe49174u, 0x54d0e25eu, 0x7d4c4a7eu, 0x4867c392u, 0x20bf409au, 0xc6e6bf10u
 };
 

--- a/C/typeSkipTest.h
+++ b/C/typeSkipTest.h
@@ -38,8 +38,8 @@ extern const size_t sizeof_typeSkipTest_witness;
 /* The commitment Merkle root of the above typeSkipTest Simplicity expression. */
 extern const uint32_t typeSkipTest_cmr[];
 
-/* The identity Merkle root of the above typeSkipTest Simplicity expression. */
-extern const uint32_t typeSkipTest_imr[];
+/* The identity hash of the root of the above typeSkipTest Simplicity expression. */
+extern const uint32_t typeSkipTest_ihr[];
 
 /* The annotated Merkle root of the above typeSkipTest Simplicity expression. */
 extern const uint32_t typeSkipTest_amr[];

--- a/Coq/Simplicity/MerkleRoot.v
+++ b/Coq/Simplicity/MerkleRoot.v
@@ -94,14 +94,14 @@ Canonical Structure CommitmentRoot_Witness_alg : Witness.Algebra :=
 Canonical Structure CommitmentRoot_AssertionWitness_alg : AssertionWitness.Algebra :=
   AssertionWitness.Pack CommitmentRoot.
 
-Definition identityRootTag := tag identityPrefix.
+Definition identityHashTag := tag identityPrefix.
 
 Section IdentityRoot.
 
 Definition IdentityRoot (A B:Ty) := hash256.
 
-Definition identityRoot {A B} (x : IdentityRoot A B) : hash256 :=
-  compress (compress_half identityRootTag x) (typeRoot A) (typeRoot B).
+Definition identityHash {A B} (x : IdentityRoot A B) : hash256 :=
+  compress (compress_half identityHashTag x) (typeRoot A) (typeRoot B).
 
 Definition IdentityRoot_Core_mixin : Core.class IdentityRoot := CommitmentRoot_Core_mixin.
 

--- a/Coq/Simplicity/Primitive.v
+++ b/Coq/Simplicity/Primitive.v
@@ -251,14 +251,14 @@ Canonical Structure JetPrimSem (M : CIMonadZero) : Algebra :=
   Pack (primSem M) (PrimSem_jet_mixin M).
 
 Definition CommitmentRoot_Jet_mixin : mixin CommitmentRoot :=
- {| Jet.jet A B t p := compress_half jetTag (identityRoot (t _))
+ {| Jet.jet A B t p := compress_half jetTag (identityHash (t _))
   |}.
 
 Canonical Structure CommitmentRoot_Jet_alg : Algebra :=
   Pack CommitmentRoot CommitmentRoot_Jet_mixin.
 
 Definition IdentityRoot_Jet_mixin : mixin IdentityRoot :=
- {| Jet.jet A B t p := compress_half jetTag (identityRoot (t _))
+ {| Jet.jet A B t p := compress_half jetTag (identityHash (t _))
   |}.
 
 Canonical Structure IdentityRoot_Jet_alg : Algebra :=

--- a/Coq/Simplicity/SHA256.v
+++ b/Coq/Simplicity/SHA256.v
@@ -462,7 +462,7 @@ Qed.
 
 Require Import Simplicity.MerkleRoot.
 
-Fact identityRoot_hashBlock : map Byte.unsigned (hash256_to_bytelist (identityRoot hashBlock)) =
+Fact identityHash_hashBlock : map Byte.unsigned (hash256_to_bytelist (identityHash hashBlock)) =
   map Byte.unsigned (sha.functional_prog.hexstring_to_bytelist "609cc1459375db728f2172c962807e3161df4cced6592d2c4e594a7779ab3175").
 Proof.
 vm_compute.

--- a/Haskell-Generate/GenPrecomputed.hs
+++ b/Haskell-Generate/GenPrecomputed.hs
@@ -66,7 +66,7 @@ declareMRIVs = vsep $ ["/* Initial values for all the tags for 'CMR's, 'AMR's an
             ++ (declCMR <$> names)
             ++ (declAMR <$> ["assertl", "assertr"] ++ names)
             ++ (declIMR <$> ["disconnect", "witness"])
-            ++ [declIV "identity" identityRootTag, declIV "hidden" hiddenTag, declIV "jet" jetTag]
+            ++ [declIV "identity" identityHashTag, declIV "hidden" hiddenTag, declIV "jet" jetTag]
  where
   declCMR name = declIV ("cmr_" ++ name) (commitmentTag name)
   declAMR name = declIV ("amr_" ++ name) (annotatedTag name)

--- a/Haskell-Generate/GenTests.hs
+++ b/Haskell-Generate/GenTests.hs
@@ -110,8 +110,8 @@ fileC example = "#include \""++example^.name++".h\"\n"
         ++ "/* The commitment Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
         ++ showHash (example^.fullname++"_cmr") cmr
         ++ "\n"
-        ++ "/* The identity Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
-        ++ showHash (example^.fullname++"_imr") imr
+        ++ "/* The identity hash of the root of the above "++example^.fullname++" Simplicity expression. */\n"
+        ++ showHash (example^.fullname++"_ihr") ihr
         ++ "\n"
         ++ "/* The annotated Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
         ++ showHash (example^.fullname++"_amr") amr
@@ -123,7 +123,7 @@ fileC example = "#include \""++example^.name++".h\"\n"
   binP = BS.unpack . runPut $ putBitStream program
   binW = BS.unpack . runPut $ putBitStream witness
   cmr = commitmentRoot . unwrap $ example^.prog
-  imr = identityRoot . unwrap $ example^.prog
+  ihr = identityHash . unwrap $ example^.prog
   amr = annotatedRoot . unwrap $ example^.prog
   cost = milliWeigh . unwrap $ example^.prog
 
@@ -143,8 +143,8 @@ fileH example = "#ifndef "++headerDef++"\n"
              ++ "/* The commitment Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
              ++ "extern const uint32_t "++example^.fullname++"_cmr[];\n"
              ++ "\n"
-             ++ "/* The identity Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
-             ++ "extern const uint32_t "++example^.fullname++"_imr[];\n"
+             ++ "/* The identity hash of the root of the above "++example^.fullname++" Simplicity expression. */\n"
+             ++ "extern const uint32_t "++example^.fullname++"_ihr[];\n"
              ++ "\n"
              ++ "/* The annotated Merkle root of the above "++example^.fullname++" Simplicity expression. */\n"
              ++ "extern const uint32_t "++example^.fullname++"_amr[];\n"

--- a/Haskell/Core/Simplicity/CoreJets.hs
+++ b/Haskell/Core/Simplicity/CoreJets.hs
@@ -2681,13 +2681,13 @@ putJetBitBitcoin ParseLock  = putPositive 1
 putJetBitBitcoin ParseSequence  = putPositive 2
 putJetBitBitcoin TapdataInit  = putPositive 3
 
--- | A 'Map.Map' from the identity roots of the "core" jet specification to their corresponding token.
+-- | A 'Map.Map' from the identity hashes of the "core" jet specification to their corresponding token.
 -- This can be used to help instantiate the 'Simplicity.JetType.matcher' method.
 coreJetMap :: Map.Map Hash256 (SomeArrow CoreJet)
 coreJetMap = Map.fromList . fmap mkAssoc $ toList coreCatalogue
  where
   mkAssoc :: SomeArrow CoreJet -> (Hash256, (SomeArrow CoreJet))
-  mkAssoc wrapped@(SomeArrow jt) = (identityRoot (specification jt), wrapped)
+  mkAssoc wrapped@(SomeArrow jt) = (identityHash (specification jt), wrapped)
 
 -- | The costs of "core" jets.  This can be used to help instantiate the 'Simplicity.JetType.jetCost' method.
 jetCost :: CoreJet a b -> Weight
@@ -3082,7 +3082,7 @@ jetCostBitcoin TapdataInit = Benchmarks.cost "TapdataInit"
 -- This operation preserves the Simplicity types.
 coreJetLookup :: (TyC a, TyC b) => IdentityRoot a b -> Maybe (CoreJet a b)
 coreJetLookup ir = do
-  SomeArrow jt <- Map.lookup (identityRoot ir) coreJetMap
+  SomeArrow jt <- Map.lookup (identityHash ir) coreJetMap
   let (ira, irb) = reifyArrow ir
   let (jta, jtb) = reifyArrow jt
   case (equalTyReflect ira jta, equalTyReflect irb jtb) of

--- a/Haskell/Core/Simplicity/MerkleRoot.hs
+++ b/Haskell/Core/Simplicity/MerkleRoot.hs
@@ -3,7 +3,7 @@
 module Simplicity.MerkleRoot
   ( typeRoot, typeRootR
   , CommitmentRoot, commitmentRoot
-  , IdentityRoot, identityRoot
+  , IdentityRoot, identityHash
   , AnnotatedRoot, annotatedRoot
   , hiddenRoot
   , signatureTag, sigHash

--- a/Haskell/Core/Simplicity/Tags.hs
+++ b/Haskell/Core/Simplicity/Tags.hs
@@ -1,7 +1,7 @@
 module Simplicity.Tags
   ( typeTag
   , commitmentTag
-  , identityRootTag, identityTag
+  , identityHashTag, identityTag
   , annotatedTag
   , primTag
   , jetTag
@@ -30,8 +30,8 @@ typeTag x = tag $ typePrefix ++ [x]
 commitmentTag :: String -> IV
 commitmentTag x = tag $ commitmentPrefix ++ [x]
 
-identityRootTag :: IV
-identityRootTag = tag identityPrefix
+identityHashTag :: IV
+identityHashTag = tag identityPrefix
 
 identityTag :: String -> IV
 identityTag x = tag $ identityPrefix ++ [x]

--- a/Haskell/Simplicity/Bitcoin/Jets.hs
+++ b/Haskell/Simplicity/Bitcoin/Jets.hs
@@ -297,7 +297,7 @@ bitcoinJetMap = Map.fromList
   ]
  where
   mkAssoc :: (TyC a, TyC b) => BitcoinJet a b -> (Hash256, (SomeArrow BitcoinJet))
-  mkAssoc jt = (identityRoot (specificationBitcoin jt), SomeArrow jt)
+  mkAssoc jt = (identityHash (specificationBitcoin jt), SomeArrow jt)
 
 data MatcherInfo a b = MatcherInfo (Product ConstWord IdentityRoot a b)
 
@@ -312,7 +312,7 @@ instance Simplicity.Bitcoin.JetType.JetType JetType where
   implementation (BitcoinJet jt) env = implementationBitcoin jt env
 
   matcher (MatcherInfo (Product cw ir)) = (do
-    SomeArrow jt <- Map.lookup (identityRoot ir) jetMap
+    SomeArrow jt <- Map.lookup (identityHash ir) jetMap
     let (ira, irb) = reifyArrow ir
     let (jta, jtb) = reifyArrow jt
     -- If the error below is thrown it suggests there is some sort of type annotation mismatch in the map below

--- a/Haskell/Simplicity/Elements/Jets.hs
+++ b/Haskell/Simplicity/Elements/Jets.hs
@@ -745,7 +745,7 @@ elementsJetMap :: Map.Map Hash256 (SomeArrow ElementsJet)
 elementsJetMap = Map.fromList . fmap mkAssoc $ toList elementsCatalogue
  where
   mkAssoc :: SomeArrow ElementsJet -> (Hash256, (SomeArrow ElementsJet))
-  mkAssoc wrapped@(SomeArrow jt) = (identityRoot (specificationElements jt), wrapped)
+  mkAssoc wrapped@(SomeArrow jt) = (identityHash (specificationElements jt), wrapped)
 
 data MatcherInfo a b = MatcherInfo (Product ConstWord IdentityRoot a b)
 
@@ -761,7 +761,7 @@ instance Simplicity.Elements.JetType.JetType JetType where
   implementation (ElementsJet jt) env = implementationElements jt env
 
   matcher (MatcherInfo (Product cw ir)) = (do
-    SomeArrow jt <- Map.lookup (identityRoot ir) jetMap
+    SomeArrow jt <- Map.lookup (identityHash ir) jetMap
     let (ira, irb) = reifyArrow ir
     let (jta, jtb) = reifyArrow jt
     -- If the error below is thrown it suggests there is some sort of type annotation mismatch in the map below

--- a/Simplicity-TR.tm
+++ b/Simplicity-TR.tm
@@ -7845,21 +7845,21 @@
   The <verbatim|Core/Simplicity/MerkleRoot.hs> module reexports functionality
   defined in <verbatim|Core/Simplicity/MerkleRoot/Impl.hs>, which provides
   instances of Simplicity terms that compute the commitment, identity and
-  annotated Merkle roots. The <verbatim|commitmentRoot>,
-  <verbatim|identityRoot>, and <verbatim|annotatedRoot> return these Merkle
-  root values. The <verbatim|Simplicity/MerkleRoot.hs> module also provides a
-  memoized computation of the Merkle roots for Simplicity types.
+  annotated Merkle roots. The <verbatim|commitmentRoot> and
+  <verbatim|annotatedRoot> return these Merkle root values. The
+  <verbatim|Simplicity/MerkleRoot.hs> module also provides a memoized
+  computation of the Merkle roots for Simplicity types.
 
   The SHA-256 implementation is provided through an abstract interface found
   in <verbatim|Core/Simplicity/Digest.hs>, which in turn references an
   implementation of a 256-bit word type defined in
   <verbatim|Core/Simplicity/Word.hs>.
 
-  The <verbatim|identityRoot> computation differs from <math|<imr0|t>> in
+  The <verbatim|identityHash> computation differs from <math|<imr0|t>> in
   that it additionally hashes in the input and output types of an expression
   <math|t>. This is done so that ensuring the uniqueness of the
   <math|<imr0|t>> and the input and outputs type triples can be effectively
-  done by just comparing the single <verbatim|identityRoot> hash value.
+  done by just comparing the single <verbatim|identityHash> value.
 
   <subsection|Tensors>
 


### PR DESCRIPTION
Renaming of identifiers in C and Haskell code to refer to identity hash instead of identity Merkle root or IMR.

What we had been calling the IMR in this code is actually hash of the triple of the identity merkle root, and the type roots of the input and output types.  The identity merkle root and the types of the input and outputs together identify expressions uniquely, which is why this combination is used in the codebase.  However the naming in the codebase was confusing.

Fixes #150.