### PR TITLE
Rename STOP code error message

### DIFF
--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -42,7 +42,7 @@ static simplicity_err getHash(sha256_midstate* result, bitstream* stream) {
 /* Decode a single node of a Simplicity dag from 'stream' into 'dag'['i'].
  * Returns 'SIMPLICITY_ERR_FAIL_CODE' if the encoding of a fail expression is encountered
  *   (all fail subexpressions ought to have been pruned prior to serialization).
- * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
+ * Returns 'SIMPLICITY_ERR_RESERVED_CODE' if a reserved codeword is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if the decoded node has illegal HIDDEN children.
  * Returns 'SIMPLICITY_ERR_DATA_OUT_OF_RANGE' if the node's child isn't a reference to one of the preceding nodes.
  *                                            or some encoding for a non-existent jet is encountered
@@ -114,7 +114,7 @@ static simplicity_err decodeNode(dag_node* dag, uint_fast32_t i, bitstream* stre
        case 0: dag[i].tag = IDEN; break;
        case 1: dag[i].tag = UNIT; break;
        case 2: return SIMPLICITY_ERR_FAIL_CODE;
-       case 3: return SIMPLICITY_ERR_STOP_CODE;
+       case 3: return SIMPLICITY_ERR_RESERVED_CODE;
       }
       break;
      case 3:
@@ -143,7 +143,7 @@ static simplicity_err decodeNode(dag_node* dag, uint_fast32_t i, bitstream* stre
  * Returns 'SIMPLICITY_ERR_DATA_OUT_OF_RANGE' if some node's child isn't a reference to one of the preceding nodes.
  * Returns 'SIMPLICITY_ERR_FAIL_CODE' if the encoding of a fail expression is encountered
  *   (all fail subexpressions ought to have been pruned prior to deserialization).
- * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
+ * Returns 'SIMPLICITY_ERR_RESERVED_CODE' if a reserved codeword is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if there are illegal HIDDEN children in the DAG.
  * Returns 'SIMPLICITY_ERR_BITSTRING_EOF' if not enough bits are available in the 'stream'.
  * In the above error cases, 'dag' may be modified.
@@ -168,7 +168,7 @@ static simplicity_err decodeDag(dag_node* dag, const uint_fast32_t len, combinat
  * Returns 'SIMPLICITY_ERR_DATA_OUT_OF_RANGE' if some node's child isn't a reference to one of the preceding nodes.
  * Returns 'SIMPLICITY_ERR_FAIL_CODE' if the encoding of a fail expression is encountered
  *  (all fail subexpressions ought to have been pruned prior to deserialization).
- * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
+ * Returns 'SIMPLICITY_ERR_RESERVED_CODE' if a reserved codeword is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if there are illegal HIDDEN children in the DAG.
  * Returns 'SIMPLICITY_ERR_HIDDEN_ROOT' if the root of the DAG is a HIDDEN node.
  * Returns 'SIMPLICITY_ERR_BITSTRING_EOF' if not enough bits are available in the 'stream'.

--- a/C/deserialize.h
+++ b/C/deserialize.h
@@ -11,7 +11,7 @@
  * Returns 'SIMPLICITY_ERR_DATA_OUT_OF_RANGE' if some node's child isn't a reference to one of the preceding nodes.
  * Returns 'SIMPLICITY_ERR_FAIL_CODE' if the encoding of a fail expression is encountered
  *  (all fail subexpressions ought to have been pruned prior to deserialization).
- * Returns 'SIMPLICITY_ERR_STOP_CODE' if the encoding of a stop tag is encountered.
+ * Returns 'SIMPLICITY_ERR_RESERVED_CODE' if a reserved codeword is encountered.
  * Returns 'SIMPLICITY_ERR_HIDDEN' if there are illegal HIDDEN children in the DAG.
  * Returns 'SIMPLICITY_ERR_HIDDEN_ROOT' if the root of the DAG is a HIDDEN node.
  * Returns 'SIMPLICITY_ERR_BITSTRING_EOF' if not enough bits are available in the 'stream'.

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -16,7 +16,7 @@ typedef enum {
   SIMPLICITY_ERR_DATA_OUT_OF_RANGE = -2,
   SIMPLICITY_ERR_DATA_OUT_OF_ORDER = -4,
   SIMPLICITY_ERR_FAIL_CODE = -6,
-  SIMPLICITY_ERR_STOP_CODE = -8,
+  SIMPLICITY_ERR_RESERVED_CODE = -8,
   SIMPLICITY_ERR_HIDDEN = -10,
   SIMPLICITY_ERR_BITSTREAM_EOF = -12,
   SIMPLICITY_ERR_BITSTREAM_TRAILING_BYTES = -14,
@@ -62,8 +62,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Non-canonical order";
   case SIMPLICITY_ERR_FAIL_CODE:
     return "Program has FAIL node";
-  case SIMPLICITY_ERR_STOP_CODE:
-    return "Program has STOP node";
+  case SIMPLICITY_ERR_RESERVED_CODE:
+    return "Program has reserved codeword";
   case SIMPLICITY_ERR_HIDDEN:
     return "Program has illegal HIDDEN child node";
   case SIMPLICITY_ERR_BITSTREAM_EOF:


### PR DESCRIPTION
In 3879496ff475b1dcaff4526d9bad4744dc0987d3 references to stop codes were removed since we never used the stop-code based serialization format. Instead this codeword has been reserved for a disconnect node without a connected child.

Such disconnected nodes cannot be used on chain, but can be used for wallet purposes where they may wish to otherwise mostly reuse the onchain serialization format.

In any case, this codeword is now considered a reserved codeword rather than a STOP code.