### PR TITLE
fix error code parsing in test harness

### DIFF
--- a/Haskell/Tests/Simplicity/Elements/FFI/Primitive.hs
+++ b/Haskell/Tests/Simplicity/Elements/FFI/Primitive.hs
@@ -16,8 +16,8 @@ data ErrorCode = BitstreamEof | DataOutOfRange deriving (Eq, Show)
 
 decodeError :: CInt -> Either ErrorCode ()
 decodeError 0 = Right ()
-decodeError (-2) = Left BitstreamEof
-decodeError (-4) = Left DataOutOfRange
+decodeError (-2) = Left DataOutOfRange
+decodeError (-12) = Left BitstreamEof
 decodeError err = error $ "Simplicity.Elements.FFI.Primitive.decodeError: Unexpected error code " ++ show err
 
 foreign import ccall unsafe "" simplicity_decodeJet :: Ptr DagNode -> Ptr Bitstream -> IO CInt


### PR DESCRIPTION
This should have been included as part of 1b85dc31d80d36dc012755e4369aeeac815476a6.