### PR TITLE
Remove unneed UBOUNDED_MAX checks

### DIFF
--- a/C/eval.c
+++ b/C/eval.c
@@ -629,19 +629,12 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
                                                , bound[dag[i].child[1]].cost ));
       break;
      case DISCONNECT:
-      if (UBOUNDED_MAX <= type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize ||
-          UBOUNDED_MAX <= type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize) {
-        /* 'BITSIZE(WORD256 * A)' or 'BITSIZE(B * C)' has exceeded our limits. */
-        bound[i].extraCellsBound[0] = UBOUNDED_MAX;
-        bound[i].extraCellsBound[1] = UBOUNDED_MAX;
-      } else {
-        bound[i].extraCellsBound[1] = type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize;
-        bound[i].extraCellsBound[0] = bounded_max(
-          bounded_add( type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize
-                     , bounded_max( bounded_add(bound[i].extraCellsBound[1], bound[dag[i].child[0]].extraCellsBound[1])
-                          , bounded_max(bound[dag[i].child[0]].extraCellsBound[0], bound[dag[i].child[1]].extraCellsBound[1]))),
-          bound[dag[i].child[1]].extraCellsBound[0]);
-      }
+      bound[i].extraCellsBound[1] = type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize;
+      bound[i].extraCellsBound[0] = bounded_max(
+        bounded_add( type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize
+                   , bounded_max( bounded_add(bound[i].extraCellsBound[1], bound[dag[i].child[0]].extraCellsBound[1])
+                                , bounded_max(bound[dag[i].child[0]].extraCellsBound[0], bound[dag[i].child[1]].extraCellsBound[1]))),
+        bound[dag[i].child[1]].extraCellsBound[0]);
       bound[i].extraUWORDBound[1] = (ubounded)ROUND_UWORD(type_dag[DISCONNECT_W256A(dag, type_dag, i)].bitSize);
       bound[i].extraUWORDBound[0] = bounded_max(
           (ubounded)ROUND_UWORD(type_dag[DISCONNECT_BC(dag, type_dag, i)].bitSize) +
@@ -660,18 +653,12 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
                     , bounded_add(bound[dag[i].child[0]].cost, bound[dag[i].child[1]].cost))))));
       break;
      case COMP:
-      if (UBOUNDED_MAX <= type_dag[COMP_B(dag, type_dag, i)].bitSize) {
-        /* 'BITSIZE(B)' has exceeded our limits. */
-        bound[i].extraCellsBound[0] = UBOUNDED_MAX;
-        bound[i].extraCellsBound[1] = UBOUNDED_MAX;
-      } else {
-        bound[i].extraCellsBound[0] = bounded_max( bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
-                                                      , bounded_max( bound[dag[i].child[0]].extraCellsBound[0]
-                                                           , bound[dag[i].child[1]].extraCellsBound[1] ))
-                                         , bound[dag[i].child[1]].extraCellsBound[0] );
-        bound[i].extraCellsBound[1] = bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
-                                                 , bound[dag[i].child[0]].extraCellsBound[1] );
-      }
+      bound[i].extraCellsBound[0] = bounded_max( bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
+                                                            , bounded_max( bound[dag[i].child[0]].extraCellsBound[0]
+                                                                         , bound[dag[i].child[1]].extraCellsBound[1] ))
+                                               , bound[dag[i].child[1]].extraCellsBound[0] );
+      bound[i].extraCellsBound[1] = bounded_add( type_dag[COMP_B(dag, type_dag, i)].bitSize
+                                               , bound[dag[i].child[0]].extraCellsBound[1] );
       bound[i].extraUWORDBound[0] = bounded_max( (ubounded)ROUND_UWORD(type_dag[COMP_B(dag, type_dag, i)].bitSize) +
                                          bounded_max( bound[dag[i].child[0]].extraUWORDBound[0]
                                             , bound[dag[i].child[1]].extraUWORDBound[1] )


### PR DESCRIPTION
For the case of `COMP`, if `type_dag[COMP_B(...)].bitSize` exceeds `UNBOUNDED_MAX`, then the bounded_add and friends functions will already set `extraCellsBound[0]` and `extraCellsBound[1]` to `UBOUNDED_MAX`.  Therefore the branch doesn't have any computational effect.  It is also not a case worth optimizing for.

The case of `DISCONNECT` is similar, however possibly only one of `extraCellsBound[0]` or `extraCellsBound[1]` will end up being set to `UBOUNDED_MAX` instead of both.

This is fine, because these values are just intermediate values for the `*cellsBound` computation at the end of the function. There we take the bounded_max of both the `extraCellsBound[0]` and `extraCellsBound[1]` functions. So the result is the same whether or not both `extraCellsBound` values are maxed out or only one is.