### PR TITLE
Add minCost parameter

### DIFF
--- a/C/elements/exec.c
+++ b/C/elements/exec.c
@@ -31,7 +31,7 @@
  *               NULL != tx;
  *               NULL != taproot;
  *               unsigned char genesisBlockHash[32]
- *               0 <= budget;
+ *               0 <= minCost <= budget;
  *               NULL != amr implies unsigned char amr[32]
  *               unsigned char program[program_len]
  *               unsigned char witness[witness_len]
@@ -39,7 +39,7 @@
 extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* ihr
                                               , const elementsTransaction* tx, uint_fast32_t ix, const elementsTapEnv* taproot
                                               , const unsigned char* genesisBlockHash
-                                              , int64_t budget
+                                              , int64_t minCost, int64_t budget
                                               , const unsigned char* amr
                                               , const unsigned char* program, size_t program_len
                                               , const unsigned char* witness, size_t witness_len) {
@@ -47,7 +47,8 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
   simplicity_assert(NULL != tx);
   simplicity_assert(NULL != taproot);
   simplicity_assert(NULL != genesisBlockHash);
-  simplicity_assert(0 <= budget);
+  simplicity_assert(0 <= minCost);
+  simplicity_assert(minCost <= budget);
   simplicity_assert(NULL != program || 0 == program_len);
   simplicity_assert(NULL != witness || 0 == witness_len);
 
@@ -120,7 +121,10 @@ extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned 
     if (IS_OK(*error)) {
       txEnv env = simplicity_elements_build_txEnv(tx, taproot, &genesis_hash, ix);
       static_assert(BUDGET_MAX <= UBOUNDED_MAX, "BUDGET_MAX doesn't fit in ubounded.");
-      *error = evalTCOProgram(dag, type_dag, (size_t)dag_len, &(ubounded){budget <= BUDGET_MAX ? (ubounded)budget : BUDGET_MAX}, &env);
+      *error = evalTCOProgram( dag, type_dag, (size_t)dag_len
+                             , minCost <= BUDGET_MAX ? (ubounded)minCost : BUDGET_MAX
+                             , &(ubounded){budget <= BUDGET_MAX ? (ubounded)budget : BUDGET_MAX}
+                             , &env);
     }
     simplicity_free(type_dag);
   }

--- a/C/eval.c
+++ b/C/eval.c
@@ -571,6 +571,7 @@ typedef struct boundsAnalysis {
  * When maxCells < UBOUNDED_MAX, if the bounds on the number of cells needed for evaluation of 'dag' on an idealized Bit Machine exceeds maxCells,
  * then return SIMPLICITY_ERR_EXEC_MEMORY.
  * When maxCost < UBOUNDED_MAX, if the bounds on the dag's CPU cost exceeds 'maxCost', then return SIMPLICITY_ERR_EXEC_BUDGET.
+ * If the bounds on the dag's CPU cost is less than or equal to 'minCost', then return SIMPLICITY_ERR_OVERWEIGHT.
  * Otherwise returns SIMPLICITY_NO_ERR.
  *
  * Precondition: NULL != cellsBound
@@ -583,11 +584,9 @@ typedef struct boundsAnalysis {
  *                 and if maxCells < UBOUNDED_MAX then '*cellsBound' bounds the number of cells needed for evaluation of 'dag' on an idealized Bit Machine
  *                 and if maxCells < UBOUNDED_MAX then '*UWORDBound' bounds the number of UWORDs needed for the frames during evaluation of 'dag'
  *                 and if maxCells < UBOUNDED_MAX then '*frameBound' bounds the number of stack frames needed during execution of 'dag'.
- *
- * :TODO: The cost calculations below are estimated and need to be replaced by experimental data.
  */
 simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubounded *frameBound, ubounded *costBound
-                            , ubounded maxCells, ubounded maxCost, const dag_node* dag, const type* type_dag, const size_t len) {
+                                       , ubounded maxCells, ubounded minCost, ubounded maxCost, const dag_node* dag, const type* type_dag, const size_t len) {
   static_assert(DAG_LEN_MAX <= SIZE_MAX / sizeof(boundsAnalysis), "bound array too large.");
   static_assert(1 <= DAG_LEN_MAX, "DAG_LEN_MAX is zero.");
   static_assert(DAG_LEN_MAX - 1 <= UINT32_MAX, "bound array index does not fit in uint32_t.");
@@ -741,6 +740,7 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
    */
   return (maxCells < *cellsBound) ? SIMPLICITY_ERR_EXEC_MEMORY
        : (maxCost < *costBound) ? SIMPLICITY_ERR_EXEC_BUDGET
+       : (*costBound <= minCost) ? SIMPLICITY_ERR_OVERWEIGHT
        : SIMPLICITY_NO_ERROR;
 }
 
@@ -748,8 +748,9 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
  * If bitSize(A) > 0, initialize the active read frame's data with 'input[ROUND_UWORD(bitSize(A))]'.
  *
  * If malloc fails, returns 'SIMPLICITY_ERR_MALLOC'.
- * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'
- * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'
+ * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'.
+ * If static analysis results determines the bound on cpu requirements is less than or equal to the minCost, returns 'SIMPLICITY_ERR_OVERWEIGHT'.
+ * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'.
  * If during execution some jet execution fails, returns 'SIMPLICITY_ERR_EXEC_JET'.
  * If during execution some 'assertr' or 'assertl' combinator fails, returns 'SIMPLICITY_ERR_EXEC_ASESRT'.
  *
@@ -764,19 +765,25 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
  *               bitSize(A) == 0 or UWORD input[ROUND_UWORD(bitSize(A))];
  *               bitSize(B) == 0 or UWORD output[ROUND_UWORD(bitSize(B))];
  *               if NULL != budget then *budget <= BUDGET_MAX
+ *               if NULL != budget then minCost <= *budget
+ *               minCost <= BUDGET_MAX
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
 simplicity_err simplicity_evalTCOExpression( flags_type anti_dos_checks, UWORD* output, const UWORD* input
-                                , const dag_node* dag, type* type_dag, size_t len, const ubounded* budget, const txEnv* env
-                                ) {
+                                           , const dag_node* dag, type* type_dag, size_t len, ubounded minCost, const ubounded* budget, const txEnv* env
+                                           ) {
   simplicity_assert(1 <= len);
   simplicity_assert(len <= DAG_LEN_MAX);
-  if (budget) { simplicity_assert(*budget <= BUDGET_MAX); }
+  if (budget) {
+    simplicity_assert(*budget <= BUDGET_MAX);
+    simplicity_assert(minCost <= *budget);
+  }
+  simplicity_assert(minCost <= BUDGET_MAX);
   static_assert(1 <= UBOUNDED_MAX, "UBOUNDED_MAX is zero.");
   static_assert(BUDGET_MAX <= (UBOUNDED_MAX - 1) / 1000, "BUDGET_MAX is too large.");
   static_assert(CELLS_MAX < UBOUNDED_MAX, "CELLS_MAX is too large.");
   ubounded cellsBound, UWORDBound, frameBound, costBound;
-  simplicity_err result = simplicity_analyseBounds(&cellsBound, &UWORDBound, &frameBound, &costBound, CELLS_MAX, budget ? *budget*1000 : UBOUNDED_MAX, dag, type_dag, len);
+  simplicity_err result = simplicity_analyseBounds(&cellsBound, &UWORDBound, &frameBound, &costBound, CELLS_MAX, minCost*1000, budget ? *budget*1000 : UBOUNDED_MAX, dag, type_dag, len);
   if (!IS_OK(result)) return result;
 
   /* frameBound is at most 2*len. */

--- a/C/eval.h
+++ b/C/eval.h
@@ -18,6 +18,7 @@ typedef unsigned char flags_type;
  * When maxCells < UBOUNDED_MAX, if the bounds on the number of cells needed for evaluation of 'dag' on an idealized Bit Machine exceeds maxCells,
  * then return SIMPLICITY_ERR_EXEC_MEMORY.
  * When maxCost < UBOUNDED_MAX, if the bounds on the dag's CPU cost exceeds 'maxCost', then return SIMPLICITY_ERR_EXEC_BUDGET.
+ * If the bounds on the dag's CPU cost is less than or equal to 'minCost', then return SIMPLICITY_ERR_OVERWEIGHT.
  * Otherwise returns SIMPLICITY_NO_ERR.
  *
  * Precondition: NULL != cellsBound
@@ -32,14 +33,15 @@ typedef unsigned char flags_type;
  *                 and if maxCells < UBOUNDED_MAX then '*frameBound' bounds the number of stack frames needed during execution of 'dag'.
  */
 simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBound, ubounded *frameBound, ubounded *costBound
-                            , ubounded maxCells, ubounded maxCost, const dag_node* dag, const type* type_dag, const size_t len);
+                                       , ubounded maxCells, ubounded minCost, ubounded maxCost, const dag_node* dag, const type* type_dag, const size_t len);
 
 /* Run the Bit Machine on the well-typed Simplicity expression 'dag[len]' of type A |- B.
  * If bitSize(A) > 0, initialize the active read frame's data with 'input[ROUND_UWORD(bitSize(A))]'.
  *
  * If malloc fails, returns 'SIMPLICITY_ERR_MALLOC'.
- * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'
- * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'
+ * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'.
+ * If static analysis results determines the bound on cpu requirements is less than or equal to the minCost, returns 'SIMPLICITY_ERR_OVERWEIGHT'.
+ * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'.
  * If during execution some jet execution fails, returns 'SIMPLICITY_ERR_EXEC_JET'.
  * If during execution some 'assertr' or 'assertl' combinator fails, returns 'SIMPLICITY_ERR_EXEC_ASESRT'.
  *
@@ -54,17 +56,20 @@ simplicity_err simplicity_analyseBounds( ubounded *cellsBound, ubounded *UWORDBo
  *               bitSize(A) == 0 or UWORD input[ROUND_UWORD(bitSize(A))];
  *               bitSize(B) == 0 or UWORD output[ROUND_UWORD(bitSize(B))];
  *               if NULL != budget then *budget <= BUDGET_MAX
+ *               if NULL != budget then minCost <= *budget
+ *               minCost <= BUDGET_MAX
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
 simplicity_err simplicity_evalTCOExpression( flags_type anti_dos_checks, UWORD* output, const UWORD* input
-                                , const dag_node* dag, type* type_dag, size_t len, const ubounded* budget, const txEnv* env
-                                );
+                                           , const dag_node* dag, type* type_dag, size_t len, ubounded minCost, const ubounded* budget, const txEnv* env
+                                           );
 
 /* Run the Bit Machine on the well-typed Simplicity program 'dag[len]'.
  *
  * If malloc fails, returns 'SIMPLICITY_ERR_MALLOC'.
- * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'
- * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'
+ * When a budget is given, if static analysis results determines the bound on cpu requirements exceed the allowed budget, returns 'SIMPLICITY_ERR_EXEC_BUDGET'.
+ * If static analysis results determines the bound on cpu requirements is less than or equal to the minCost, returns 'SIMPLICITY_ERR_OVERWEIGHT'.
+ * If static analysis results determines the bound on memory allocation requirements exceed the allowed limits, returns 'SIMPLICITY_ERR_EXEC_MEMORY'.
  * If during execution some jet execution fails, returns 'SIMPLICITY_ERR_EXEC_JET'.
  * If during execution some 'assertr' or 'assertl' combinator fails, returns 'SIMPLICITY_ERR_EXEC_ASESRT'.
  * If not every non-HIDDEN dag node is executed, returns 'SIMPLICITY_ERR_ANTIDOS'
@@ -74,9 +79,11 @@ simplicity_err simplicity_evalTCOExpression( flags_type anti_dos_checks, UWORD* 
  *
  * Precondition: dag_node dag[len] and 'dag' is well-typed with 'type_dag' for an expression of type ONE |- ONE;
  *               if NULL != budget then *budget <= BUDGET_MAX
+ *               if NULL != budget then minCost <= *budget
+ *               minCost <= BUDGET_MAX
  *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
-static inline simplicity_err evalTCOProgram(const dag_node* dag, type* type_dag, size_t len, const ubounded* budget, const txEnv* env) {
-  return simplicity_evalTCOExpression(CHECK_ALL, NULL, NULL, dag, type_dag, len, budget, env);
+static inline simplicity_err evalTCOProgram(const dag_node* dag, type* type_dag, size_t len, ubounded minCost, const ubounded* budget, const txEnv* env) {
+  return simplicity_evalTCOExpression(CHECK_ALL, NULL, NULL, dag, type_dag, len, minCost, budget, env);
 }
 #endif

--- a/C/include/simplicity/elements/exec.h
+++ b/C/include/simplicity/elements/exec.h
@@ -27,7 +27,7 @@
  *               NULL != tx;
  *               NULL != taproot;
  *               unsigned char genesisBlockHash[32]
- *               0 <= budget;
+ *               0 <= minCost <= budget;
  *               NULL != amr implies unsigned char amr[32]
  *               unsigned char program[program_len]
  *               unsigned char witness[witness_len]
@@ -35,7 +35,7 @@
 extern bool simplicity_elements_execSimplicity( simplicity_err* error, unsigned char* ihr
                                               , const elementsTransaction* tx, uint_fast32_t ix, const elementsTapEnv* taproot
                                               , const unsigned char* genesisBlockHash
-                                              , int64_t budget
+                                              , int64_t minCost, int64_t budget
                                               , const unsigned char* amr
                                               , const unsigned char* program, size_t program_len
                                               , const unsigned char* witness, size_t witness_len);

--- a/C/include/simplicity/errorCodes.h
+++ b/C/include/simplicity/errorCodes.h
@@ -36,6 +36,7 @@ typedef enum {
   SIMPLICITY_ERR_ANTIDOS = -42,
   SIMPLICITY_ERR_HIDDEN_ROOT = -44,
   SIMPLICITY_ERR_AMR = -46,
+  SIMPLICITY_ERR_OVERWEIGHT = -48,
 } simplicity_err;
 
 /* Check if failure is permanent (or success which is always permanent). */
@@ -102,6 +103,8 @@ static inline const char * SIMPLICITY_ERR_MSG(simplicity_err err) {
     return "Program's root is HIDDEN";
   case SIMPLICITY_ERR_AMR:
     return "Program's AMR does not match";
+  case SIMPLICITY_ERR_OVERWEIGHT:
+    return "Program's budget is too large";
   default:
     return "Unknown error code";
   }


### PR DESCRIPTION
This is designed to support exact annex padding standardness rule by returning an OVERWEIGHT condition when the computed cost is below some minCost.

Setting minCost to 0 effectively nullifies this check.

Technically setting the minCost rejects programs that have a computed cost of 0, however there are no Simplicity programs that have a computed cost of 0 since every Simplicity program must contain at least one node, and hence has at least 'overhead' cost, which is 100 milliWU.