### PR TITLE
Update new paths in GenRustJets

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -436,7 +436,7 @@ rustWrapperDoc mod = layoutPretty layoutOptions $ vsep (map (<> line)
 
 cWrapperImports :: Doc a
 cWrapperImports = vsep
-  [ "#include \"simplicity/primitive/elements/elementsJets.h\""
+  [ "#include \"simplicity/elements/elementsJets.h\""
   , "#include \"simplicity/simplicity_assert.h\""
   , "#include \"wrapper.h\""
   ]


### PR DESCRIPTION
We recently eliminated the `primitive` directory.