### PR TITLE
Haskell-Generate: stop referring to `Midstate` explicitly

### DIFF
--- a/Haskell-Generate/GenRustJets.hs
+++ b/Haskell-Generate/GenRustJets.hs
@@ -157,7 +157,7 @@ rustJetCmr mod = vsep $
         ]))
     , "};"
     , mempty
-    , "Cmr(Midstate(bytes))"
+    , "Cmr::from_byte_array(bytes)"
     ]))
   , "}"
   ]
@@ -338,7 +338,6 @@ rustImports mod = vsep (map (<> semi)
   , "use crate::decode_bits"
   , "use crate::{decode, BitIter, BitWriter}"
   , "use crate::analysis::Cost"
-  , "use hashes::sha256::Midstate"
   , "use simplicity_sys::CFrameItem"
   , "use std::io::Write"
   , "use std::{fmt, str}"


### PR DESCRIPTION
This is an unnecessary encapsulation violation (Haskell-Generate doesn't need to know how Cmr is implemented when it just needs to construct one from a byte array), and also it'll stop working when we move to bitcoin_hashes 1.0.